### PR TITLE
Make ExampleGenerator work under non-Windows OSs

### DIFF
--- a/ExampleGenerator/Annotations/LineAnnotationExamples.cs
+++ b/ExampleGenerator/Annotations/LineAnnotationExamples.cs
@@ -1,19 +1,16 @@
-﻿namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Annotations;
-    using OxyPlot.Axes;
+﻿namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Annotations;
+	using OxyPlot.Axes;
 
-    public class LineAnnotationExamples
-    {
-        [Export(@"Annotations\LineAnnotation")]
-        public static PlotModel LineAnnotation()
-        {
-            var model = new PlotModel { Title = "LineAnnotation" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-            model.Annotations.Add(new LineAnnotation { X = 50, Type = LineAnnotationType.Vertical, Text = "Vertical LineAnnotation" });
-            return model;
-        }
-    }
+	public class LineAnnotationExamples {
+		[Export("Annotations/LineAnnotation")]
+		public static PlotModel LineAnnotation() {
+			var model = new PlotModel { Title = "LineAnnotation" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+			model.Annotations.Add(new LineAnnotation { X = 50, Type = LineAnnotationType.Vertical, Text = "Vertical LineAnnotation" });
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Annotations/LineAnnotationExamples.cs
+++ b/ExampleGenerator/Annotations/LineAnnotationExamples.cs
@@ -1,16 +1,19 @@
-﻿namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Annotations;
-	using OxyPlot.Axes;
+﻿namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Annotations;
+    using OxyPlot.Axes;
 
-	public class LineAnnotationExamples {
-		[Export("Annotations/LineAnnotation")]
-		public static PlotModel LineAnnotation() {
-			var model = new PlotModel { Title = "LineAnnotation" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-			model.Annotations.Add(new LineAnnotation { X = 50, Type = LineAnnotationType.Vertical, Text = "Vertical LineAnnotation" });
-			return model;
-		}
-	}
+    public class LineAnnotationExamples
+    {
+        [Export("Annotations/LineAnnotation")]
+        public static PlotModel LineAnnotation()
+        {
+            var model = new PlotModel { Title = "LineAnnotation" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            model.Annotations.Add(new LineAnnotation { X = 50, Type = LineAnnotationType.Vertical, Text = "Vertical LineAnnotation" });
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Axes/AxisExamples.cs
+++ b/ExampleGenerator/Axes/AxisExamples.cs
@@ -1,64 +1,73 @@
-namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Axes;
+namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Axes;
 
-	public class AxisExamples {
-		[Export("Axes/Position")]
-		public static PlotModel Position() {
-			var model = new PlotModel { Title = "Position" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "Bottom" });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Left" });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Top, Title = "Top" });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Right, Title = "Right" });
-			return model;
-		}
+    public class AxisExamples
+    {
+        [Export("Axes/Position")]
+        public static PlotModel Position()
+        {
+            var model = new PlotModel { Title = "Position" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "Bottom" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Left" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Top, Title = "Top" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Right, Title = "Right" });
+            return model;
+        }
 
-		[Export("Axes/MinimumMaximum")]
-		public static PlotModel MinimumMaximum() {
-			var model = new PlotModel { Title = "Minimum and Maximum" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1, Maximum = 1 });
-			return model;
-		}
+        [Export("Axes/MinimumMaximum")]
+        public static PlotModel MinimumMaximum()
+        {
+            var model = new PlotModel { Title = "Minimum and Maximum" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1, Maximum = 1 });
+            return model;
+        }
 
-		[Export("Axes/MajorStep")]
-		public static PlotModel MajorStep() {
-			var model = new PlotModel { Title = "MajorStep" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 10, MajorStep = 2 });
-			return model;
-		}
+        [Export("Axes/MajorStep")]
+        public static PlotModel MajorStep()
+        {
+            var model = new PlotModel { Title = "MajorStep" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 10, MajorStep = 2 });
+            return model;
+        }
 
-		[Export("Axes/MinorStep")]
-		public static PlotModel MinorStep() {
-			var model = new PlotModel { Title = "MinorStep" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 10, MajorStep = 1, MinorStep = 0.2 });
-			return model;
-		}
+        [Export("Axes/MinorStep")]
+        public static PlotModel MinorStep()
+        {
+            var model = new PlotModel { Title = "MinorStep" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 10, MajorStep = 1, MinorStep = 0.2 });
+            return model;
+        }
 
-		[Export("Axes/PositionTier")]
-		public static PlotModel PositionTier() {
-			var model = new PlotModel { Title = "PositionTier" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, PositionTier = 0, Title = "PositionTier = 0" });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, PositionTier = 1, Minimum = 0, Maximum = 1, Title = "PositionTier = 1" });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, PositionTier = 0, Title = "PositionTier = 0" });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, PositionTier = 1, Minimum = 0, Maximum = 10, Title = "PositionTier = 1" });
-			return model;
-		}
+        [Export("Axes/PositionTier")]
+        public static PlotModel PositionTier()
+        {
+            var model = new PlotModel { Title = "PositionTier" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, PositionTier = 0, Title = "PositionTier = 0" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, PositionTier = 1, Minimum = 0, Maximum = 1, Title = "PositionTier = 1" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, PositionTier = 0, Title = "PositionTier = 0" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, PositionTier = 1, Minimum = 0, Maximum = 10, Title = "PositionTier = 1" });
+            return model;
+        }
 
-		[Export("Axes/Reversed")]
-		public static PlotModel StartEndPositionReversed() {
-			var model = new PlotModel { Title = "Reversed axes" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 1, EndPosition = 0 });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, StartPosition = 1, EndPosition = 0 });
-			return model;
-		}
+        [Export("Axes/Reversed")]
+        public static PlotModel StartEndPositionReversed()
+        {
+            var model = new PlotModel { Title = "Reversed axes" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 1, EndPosition = 0 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, StartPosition = 1, EndPosition = 0 });
+            return model;
+        }
 
-		[Export("Axes/StartEndPosition")]
-		public static PlotModel StartEndPosition() {
-			var model = new PlotModel { Title = "StartPosition and EndPosition" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 0, EndPosition = 0.45, Title = "First" });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 0.55, EndPosition = 1, Title = "Second" });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-			return model;
-		}
-	}
+        [Export("Axes/StartEndPosition")]
+        public static PlotModel StartEndPosition()
+        {
+            var model = new PlotModel { Title = "StartPosition and EndPosition" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 0, EndPosition = 0.45, Title = "First" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 0.55, EndPosition = 1, Title = "Second" });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Axes/AxisExamples.cs
+++ b/ExampleGenerator/Axes/AxisExamples.cs
@@ -1,73 +1,64 @@
-namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Axes;
+namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Axes;
 
-    public class AxisExamples
-    {
-        [Export(@"Axes\Position")]
-        public static PlotModel Position()
-        {
-            var model = new PlotModel { Title = "Position" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "Bottom" });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Left" });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Top, Title = "Top" });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Right, Title = "Right" });
-            return model;
-        }
+	public class AxisExamples {
+		[Export("Axes/Position")]
+		public static PlotModel Position() {
+			var model = new PlotModel { Title = "Position" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Title = "Bottom" });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Title = "Left" });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Top, Title = "Top" });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Right, Title = "Right" });
+			return model;
+		}
 
-        [Export(@"Axes\MinimumMaximum")]
-        public static PlotModel MinimumMaximum()
-        {
-            var model = new PlotModel { Title = "Minimum and Maximum" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1, Maximum = 1 });
-            return model;
-        }
+		[Export("Axes/MinimumMaximum")]
+		public static PlotModel MinimumMaximum() {
+			var model = new PlotModel { Title = "Minimum and Maximum" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1, Maximum = 1 });
+			return model;
+		}
 
-        [Export(@"Axes\MajorStep")]
-        public static PlotModel MajorStep()
-        {
-            var model = new PlotModel { Title = "MajorStep" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 10, MajorStep = 2 });
-            return model;
-        }
+		[Export("Axes/MajorStep")]
+		public static PlotModel MajorStep() {
+			var model = new PlotModel { Title = "MajorStep" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 10, MajorStep = 2 });
+			return model;
+		}
 
-        [Export(@"Axes\MinorStep")]
-        public static PlotModel MinorStep()
-        {
-            var model = new PlotModel { Title = "MinorStep" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 10, MajorStep = 1, MinorStep = 0.2 });
-            return model;
-        }
+		[Export("Axes/MinorStep")]
+		public static PlotModel MinorStep() {
+			var model = new PlotModel { Title = "MinorStep" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 10, MajorStep = 1, MinorStep = 0.2 });
+			return model;
+		}
 
-        [Export(@"Axes\PositionTier")]
-        public static PlotModel PositionTier()
-        {
-            var model = new PlotModel { Title = "PositionTier" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, PositionTier = 0, Title = "PositionTier = 0" });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, PositionTier = 1, Minimum = 0, Maximum = 1, Title = "PositionTier = 1" });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, PositionTier = 0, Title = "PositionTier = 0" });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, PositionTier = 1, Minimum = 0, Maximum = 10, Title = "PositionTier = 1" });
-            return model;
-        }
+		[Export("Axes/PositionTier")]
+		public static PlotModel PositionTier() {
+			var model = new PlotModel { Title = "PositionTier" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, PositionTier = 0, Title = "PositionTier = 0" });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, PositionTier = 1, Minimum = 0, Maximum = 1, Title = "PositionTier = 1" });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, PositionTier = 0, Title = "PositionTier = 0" });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, PositionTier = 1, Minimum = 0, Maximum = 10, Title = "PositionTier = 1" });
+			return model;
+		}
 
-        [Export(@"Axes\Reversed")]
-        public static PlotModel StartEndPositionReversed()
-        {
-            var model = new PlotModel { Title = "Reversed axes" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 1, EndPosition = 0 });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, StartPosition = 1, EndPosition = 0 });
-            return model;
-        }
+		[Export("Axes/Reversed")]
+		public static PlotModel StartEndPositionReversed() {
+			var model = new PlotModel { Title = "Reversed axes" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 1, EndPosition = 0 });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, StartPosition = 1, EndPosition = 0 });
+			return model;
+		}
 
-        [Export(@"Axes\StartEndPosition")]
-        public static PlotModel StartEndPosition()
-        {
-            var model = new PlotModel { Title = "StartPosition and EndPosition" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 0, EndPosition = 0.45, Title = "First" });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 0.55, EndPosition = 1, Title = "Second" });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-            return model;
-        }
-    }
+		[Export("Axes/StartEndPosition")]
+		public static PlotModel StartEndPosition() {
+			var model = new PlotModel { Title = "StartPosition and EndPosition" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 0, EndPosition = 0.45, Title = "First" });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, StartPosition = 0.55, EndPosition = 1, Title = "Second" });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Axes/DateTimeAxisExamples.cs
+++ b/ExampleGenerator/Axes/DateTimeAxisExamples.cs
@@ -1,22 +1,25 @@
-namespace ExampleGenerator {
-	using System;
+namespace ExampleGenerator
+{
+    using System;
 
-	using OxyPlot;
-	using OxyPlot.Axes;
+    using OxyPlot;
+    using OxyPlot.Axes;
 
-	public class DateTimeAxisExamples {
-		[Export("Axes/DateTimeAxis")]
-		public static PlotModel Default() {
-			var model = new PlotModel { Title = "DateTimeAxis", PlotMargins = new OxyThickness(40, double.NaN, 40, double.NaN) };
-			model.Axes.Add(new DateTimeAxis
-			{
-				Position = AxisPosition.Bottom,
-				Minimum = DateTimeAxis.ToDouble(new DateTime(2015, 1, 1)),
-				Maximum = DateTimeAxis.ToDouble(new DateTime(2016, 1, 1)),
-				Title = "DateTimeAxis"
-			});
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-			return model;
-		}
-	}
+    public class DateTimeAxisExamples
+    {
+        [Export("Axes/DateTimeAxis")]
+        public static PlotModel Default()
+        {
+            var model = new PlotModel { Title = "DateTimeAxis", PlotMargins = new OxyThickness(40, double.NaN, 40, double.NaN) };
+            model.Axes.Add(new DateTimeAxis
+                {
+                    Position = AxisPosition.Bottom,
+                    Minimum = DateTimeAxis.ToDouble(new DateTime(2015, 1, 1)),
+                    Maximum = DateTimeAxis.ToDouble(new DateTime(2016, 1, 1)),
+                    Title = "DateTimeAxis"
+                });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Axes/DateTimeAxisExamples.cs
+++ b/ExampleGenerator/Axes/DateTimeAxisExamples.cs
@@ -1,25 +1,22 @@
-namespace ExampleGenerator
-{
-    using System;
+namespace ExampleGenerator {
+	using System;
 
-    using OxyPlot;
-    using OxyPlot.Axes;
+	using OxyPlot;
+	using OxyPlot.Axes;
 
-    public class DateTimeAxisExamples
-    {
-        [Export(@"Axes\DateTimeAxis")]
-        public static PlotModel Default()
-        {
-            var model = new PlotModel { Title = "DateTimeAxis", PlotMargins = new OxyThickness(40, double.NaN, 40, double.NaN) };
-            model.Axes.Add(new DateTimeAxis
-            {
-                Position = AxisPosition.Bottom,
-                Minimum = DateTimeAxis.ToDouble(new DateTime(2015, 1, 1)),
-                Maximum = DateTimeAxis.ToDouble(new DateTime(2016, 1, 1)),
-                Title = "DateTimeAxis"
-            });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-            return model;
-        }
-    }
+	public class DateTimeAxisExamples {
+		[Export("Axes/DateTimeAxis")]
+		public static PlotModel Default() {
+			var model = new PlotModel { Title = "DateTimeAxis", PlotMargins = new OxyThickness(40, double.NaN, 40, double.NaN) };
+			model.Axes.Add(new DateTimeAxis
+			{
+				Position = AxisPosition.Bottom,
+				Minimum = DateTimeAxis.ToDouble(new DateTime(2015, 1, 1)),
+				Maximum = DateTimeAxis.ToDouble(new DateTime(2016, 1, 1)),
+				Title = "DateTimeAxis"
+			});
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Axes/LinearAxisExamples.cs
+++ b/ExampleGenerator/Axes/LinearAxisExamples.cs
@@ -1,14 +1,17 @@
-﻿namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Axes;
+﻿namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Axes;
 
-	public class LinearAxisExamples {
-		[Export("Axes/LinearAxis")]
-		public static PlotModel LinearAxis() {
-			var model = new PlotModel { Title = "LinearAxis" };
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1, Maximum = 1 });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -10, Maximum = 10 });
-			return model;
-		}
-	}
+    public class LinearAxisExamples
+    {
+        [Export("Axes/LinearAxis")]
+        public static PlotModel LinearAxis()
+        {
+            var model = new PlotModel { Title = "LinearAxis" };
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1, Maximum = 1 });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -10, Maximum = 10 });
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Axes/LinearAxisExamples.cs
+++ b/ExampleGenerator/Axes/LinearAxisExamples.cs
@@ -1,17 +1,14 @@
-﻿namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Axes;
+﻿namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Axes;
 
-    public class LinearAxisExamples
-    {
-        [Export(@"Axes\LinearAxis")]
-        public static PlotModel LinearAxis()
-        {
-            var model = new PlotModel { Title = "LinearAxis" };
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1, Maximum = 1 });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -10, Maximum = 10 });
-            return model;
-        }
-    }
+	public class LinearAxisExamples {
+		[Export("Axes/LinearAxis")]
+		public static PlotModel LinearAxis() {
+			var model = new PlotModel { Title = "LinearAxis" };
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = -1, Maximum = 1 });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left, Minimum = -10, Maximum = 10 });
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Axes/LogarithmicAxisExamples.cs
+++ b/ExampleGenerator/Axes/LogarithmicAxisExamples.cs
@@ -1,17 +1,14 @@
-namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Axes;
+namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Axes;
 
-    public class LogarithmicAxisExamples
-    {
-        [Export(@"Axes\LogarithmicAxis")]
-        public static PlotModel LogarithmicAxis()
-        {
-            var model = new PlotModel { Title = "LogarithmicAxis" };
-            model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Bottom, Minimum = 1e0, Maximum = 1e3 });
-            model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Left, Minimum = 1e-4, Maximum = 1e-1 });
-            return model;
-        }
-    }
+	public class LogarithmicAxisExamples {
+		[Export("Axes/LogarithmicAxis")]
+		public static PlotModel LogarithmicAxis() {
+			var model = new PlotModel { Title = "LogarithmicAxis" };
+			model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Bottom, Minimum = 1e0, Maximum = 1e3 });
+			model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Left, Minimum = 1e-4, Maximum = 1e-1 });
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Axes/LogarithmicAxisExamples.cs
+++ b/ExampleGenerator/Axes/LogarithmicAxisExamples.cs
@@ -1,14 +1,17 @@
-namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Axes;
+namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Axes;
 
-	public class LogarithmicAxisExamples {
-		[Export("Axes/LogarithmicAxis")]
-		public static PlotModel LogarithmicAxis() {
-			var model = new PlotModel { Title = "LogarithmicAxis" };
-			model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Bottom, Minimum = 1e0, Maximum = 1e3 });
-			model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Left, Minimum = 1e-4, Maximum = 1e-1 });
-			return model;
-		}
-	}
+    public class LogarithmicAxisExamples
+    {
+        [Export("Axes/LogarithmicAxis")]
+        public static PlotModel LogarithmicAxis()
+        {
+            var model = new PlotModel { Title = "LogarithmicAxis" };
+            model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Bottom, Minimum = 1e0, Maximum = 1e3 });
+            model.Axes.Add(new LogarithmicAxis { Position = AxisPosition.Left, Minimum = 1e-4, Maximum = 1e-1 });
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Axes/PolarPlotExamples.cs
+++ b/ExampleGenerator/Axes/PolarPlotExamples.cs
@@ -1,17 +1,14 @@
-namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Axes;
+namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Axes;
 
-    public class PolarPlotExamples
-    {
-        [Export(@"Axes\AngleAndMagnitudeAxis")]
-        public static PlotModel Default()
-        {
-            var model = new PlotModel { Title = "AngleAxis and MagnitudeAxis", PlotType = PlotType.Polar };
-            model.Axes.Add(new AngleAxis { Title = "Angle" });
-            model.Axes.Add(new MagnitudeAxis { Title = "Magnitude" });
-            return model;
-        }
-    }
+	public class PolarPlotExamples {
+		[Export("Axes/AngleAndMagnitudeAxis")]
+		public static PlotModel Default() {
+			var model = new PlotModel { Title = "AngleAxis and MagnitudeAxis", PlotType = PlotType.Polar };
+			model.Axes.Add(new AngleAxis { Title = "Angle" });
+			model.Axes.Add(new MagnitudeAxis { Title = "Magnitude" });
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Axes/PolarPlotExamples.cs
+++ b/ExampleGenerator/Axes/PolarPlotExamples.cs
@@ -1,14 +1,17 @@
-namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Axes;
+namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Axes;
 
-	public class PolarPlotExamples {
-		[Export("Axes/AngleAndMagnitudeAxis")]
-		public static PlotModel Default() {
-			var model = new PlotModel { Title = "AngleAxis and MagnitudeAxis", PlotType = PlotType.Polar };
-			model.Axes.Add(new AngleAxis { Title = "Angle" });
-			model.Axes.Add(new MagnitudeAxis { Title = "Magnitude" });
-			return model;
-		}
-	}
+    public class PolarPlotExamples
+    {
+        [Export("Axes/AngleAndMagnitudeAxis")]
+        public static PlotModel Default()
+        {
+            var model = new PlotModel { Title = "AngleAxis and MagnitudeAxis", PlotType = PlotType.Polar };
+            model.Axes.Add(new AngleAxis { Title = "Angle" });
+            model.Axes.Add(new MagnitudeAxis { Title = "Magnitude" });
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Axes/TimeSpanAxisExamples.cs
+++ b/ExampleGenerator/Axes/TimeSpanAxisExamples.cs
@@ -1,19 +1,16 @@
-namespace ExampleGenerator
-{
-    using System;
+namespace ExampleGenerator {
+	using System;
 
-    using OxyPlot;
-    using OxyPlot.Axes;
+	using OxyPlot;
+	using OxyPlot.Axes;
 
-    public class TimeSpanAxisExamples
-    {
-        [Export(@"Axes\TimeSpanAxis")]
-        public static PlotModel Default()
-        {
-            var model = new PlotModel { Title = "TimeSpanAxis" };
-            model.Axes.Add(new TimeSpanAxis { Position = AxisPosition.Bottom, Maximum = TimeSpanAxis.ToDouble(TimeSpan.FromMinutes(15)) });
-            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-            return model;
-        }
-    }
+	public class TimeSpanAxisExamples {
+		[Export("Axes/TimeSpanAxis")]
+		public static PlotModel Default() {
+			var model = new PlotModel { Title = "TimeSpanAxis" };
+			model.Axes.Add(new TimeSpanAxis { Position = AxisPosition.Bottom, Maximum = TimeSpanAxis.ToDouble(TimeSpan.FromMinutes(15)) });
+			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Axes/TimeSpanAxisExamples.cs
+++ b/ExampleGenerator/Axes/TimeSpanAxisExamples.cs
@@ -1,16 +1,19 @@
-namespace ExampleGenerator {
-	using System;
+namespace ExampleGenerator
+{
+    using System;
 
-	using OxyPlot;
-	using OxyPlot.Axes;
+    using OxyPlot;
+    using OxyPlot.Axes;
 
-	public class TimeSpanAxisExamples {
-		[Export("Axes/TimeSpanAxis")]
-		public static PlotModel Default() {
-			var model = new PlotModel { Title = "TimeSpanAxis" };
-			model.Axes.Add(new TimeSpanAxis { Position = AxisPosition.Bottom, Maximum = TimeSpanAxis.ToDouble(TimeSpan.FromMinutes(15)) });
-			model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
-			return model;
-		}
-	}
+    public class TimeSpanAxisExamples
+    {
+        [Export("Axes/TimeSpanAxis")]
+        public static PlotModel Default()
+        {
+            var model = new PlotModel { Title = "TimeSpanAxis" };
+            model.Axes.Add(new TimeSpanAxis { Position = AxisPosition.Bottom, Maximum = TimeSpanAxis.ToDouble(TimeSpan.FromMinutes(15)) });
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Left });
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/ExportAttribute.cs
+++ b/ExampleGenerator/ExportAttribute.cs
@@ -1,26 +1,29 @@
-﻿namespace ExampleGenerator {
-	using System;
+﻿namespace ExampleGenerator
+{
+    using System;
 
-	/// <summary>
-	/// Defines that the model should be exported.
-	/// </summary>
-	public class ExportAttribute : Attribute {
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ExportAttribute"/> class.
-		/// </summary>
-		/// <param name="filename">The filename.</param>
-		public ExportAttribute(string filename) {
-			this.Filename = filename;
-		}
+    /// <summary>
+    /// Defines that the model should be exported.
+    /// </summary>
+    public class ExportAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportAttribute"/> class.
+        /// </summary>
+        /// <param name="filename">The filename.</param>
+        public ExportAttribute(string filename)
+        {
+            this.Filename = filename;
+        }
 
-		/// <summary>
-		/// Gets the filename.
-		/// </summary>
-		/// <value>The filename.</value>
-		/// <remarks>
-		/// For sub folders, use '/' as path delimiter.
-		/// This is then replaced with the current platforms path separator later in the process.
-		/// </remarks>
-		public string Filename { get; private set; }
-	}
+        /// <summary>
+        /// Gets the filename.
+        /// </summary>
+        /// <value>The filename.</value>
+        /// <remarks>
+        /// For sub folders, use '/' as path delimiter.
+        /// This is then replaced with the current platforms path separator later in the process.
+        /// </remarks>
+        public string Filename { get; private set; }
+    }
 }

--- a/ExampleGenerator/ExportAttribute.cs
+++ b/ExampleGenerator/ExportAttribute.cs
@@ -1,25 +1,26 @@
-﻿namespace ExampleGenerator
-{
-    using System;
+﻿namespace ExampleGenerator {
+	using System;
 
-    /// <summary>
-    /// Defines that the model should be exported.
-    /// </summary>
-    public class ExportAttribute : Attribute
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExportAttribute"/> class.
-        /// </summary>
-        /// <param name="filename">The filename.</param>
-        public ExportAttribute(string filename)
-        {
-            this.Filename = filename;
-        }
+	/// <summary>
+	/// Defines that the model should be exported.
+	/// </summary>
+	public class ExportAttribute : Attribute {
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ExportAttribute"/> class.
+		/// </summary>
+		/// <param name="filename">The filename.</param>
+		public ExportAttribute(string filename) {
+			this.Filename = filename;
+		}
 
-        /// <summary>
-        /// Gets the filename.
-        /// </summary>
-        /// <value>The filename.</value>
-        public string Filename { get; private set; }
-    }
+		/// <summary>
+		/// Gets the filename.
+		/// </summary>
+		/// <value>The filename.</value>
+		/// <remarks>
+		/// For sub folders, use '/' as path delimiter.
+		/// This is then replaced with the current platforms path separator later in the process.
+		/// </remarks>
+		public string Filename { get; private set; }
+	}
 }

--- a/ExampleGenerator/Misc/BindingExamples.cs
+++ b/ExampleGenerator/Misc/BindingExamples.cs
@@ -1,13 +1,10 @@
-namespace ExampleGenerator
-{
-    using OxyPlot;
+namespace ExampleGenerator {
+	using OxyPlot;
 
-    public static class BindingExamples
-    {
-        [Export(@"BindingExamples\Example1")]
-        public static PlotModel Example1()
-        {
-            return new PlotModel { Title = "TODO" };
-        }
-    }
+	public static class BindingExamples {
+		[Export("BindingExamples/Example1")]
+		public static PlotModel Example1() {
+			return new PlotModel { Title = "TODO" };
+		}
+	}
 }

--- a/ExampleGenerator/Misc/BindingExamples.cs
+++ b/ExampleGenerator/Misc/BindingExamples.cs
@@ -1,10 +1,13 @@
-namespace ExampleGenerator {
-	using OxyPlot;
+namespace ExampleGenerator
+{
+    using OxyPlot;
 
-	public static class BindingExamples {
-		[Export("BindingExamples/Example1")]
-		public static PlotModel Example1() {
-			return new PlotModel { Title = "TODO" };
-		}
-	}
+    public static class BindingExamples
+    {
+        [Export("BindingExamples/Example1")]
+        public static PlotModel Example1()
+        {
+            return new PlotModel { Title = "TODO" };
+        }
+    }
 }

--- a/ExampleGenerator/Misc/Showcases.cs
+++ b/ExampleGenerator/Misc/Showcases.cs
@@ -1,60 +1,65 @@
-﻿namespace ExampleGenerator {
-	using System;
-	using System.Globalization;
+﻿namespace ExampleGenerator
+{
+    using System;
+    using System.Globalization;
 
-	using OxyPlot;
-	using OxyPlot.Axes;
-	using OxyPlot.Series;
+    using OxyPlot;
+    using OxyPlot.Axes;
+    using OxyPlot.Series;
 
-	public static class Showcases {
-		[Export("Showcases/NormalDistribution")]
-		public static PlotModel LineSeries() {
-			// http://en.wikipedia.org/wiki/Normal_distribution
-			var plot = new PlotModel
-			{
-				Title = "Normal distribution",
-				Subtitle = "Probability density function",
-				DefaultFont = "Arial",
-				Culture = CultureInfo.InvariantCulture
-			};
+    public static class Showcases
+    {
+        [Export("Showcases/NormalDistribution")]
+        public static PlotModel LineSeries()
+        {
+            // http://en.wikipedia.org/wiki/Normal_distribution
+            var plot = new PlotModel
+            {
+                Title = "Normal distribution",
+                Subtitle = "Probability density function",
+                DefaultFont = "Arial",
+                Culture = CultureInfo.InvariantCulture
+            };
 
-			plot.Axes.Add(
-				new LinearAxis
-				{
-					Position = AxisPosition.Left,
-					Minimum = -0.05,
-					Maximum = 1.05,
-					MajorStep = 0.2,
-					MinorStep = 0.05,
-					TickStyle = TickStyle.Inside
-				});
-			plot.Axes.Add(
-				new LinearAxis
-				{
-					Position = AxisPosition.Bottom,
-					Minimum = -5.25,
-					Maximum = 5.25,
-					MajorStep = 1,
-					MinorStep = 0.25,
-					TickStyle = TickStyle.Inside
-				});
-			plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 0.2));
-			plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 1));
-			plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 5));
-			plot.Series.Add(CreateNormalDistributionSeries(-5, 5, -2, 0.5));
-			return plot;
-		}
+            plot.Axes.Add(
+                new LinearAxis
+                {
+                    Position = AxisPosition.Left,
+                    Minimum = -0.05,
+                    Maximum = 1.05,
+                    MajorStep = 0.2,
+                    MinorStep = 0.05,
+                    TickStyle = TickStyle.Inside
+                });
+            plot.Axes.Add(
+                new LinearAxis
+                {
+                    Position = AxisPosition.Bottom,
+                    Minimum = -5.25,
+                    Maximum = 5.25,
+                    MajorStep = 1,
+                    MinorStep = 0.25,
+                    TickStyle = TickStyle.Inside
+                });
+            plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 0.2));
+            plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 1));
+            plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 5));
+            plot.Series.Add(CreateNormalDistributionSeries(-5, 5, -2, 0.5));
+            return plot;
+        }
 
-		private static DataPointSeries CreateNormalDistributionSeries(double x0, double x1, double mean, double variance, int n = 1001) {
-			var ls = new LineSeries { Title = string.Format(CultureInfo.InvariantCulture, "N({0},{1})", mean, variance) };
+        private static DataPointSeries CreateNormalDistributionSeries(double x0, double x1, double mean, double variance, int n = 1001)
+        {
+            var ls = new LineSeries { Title = string.Format(CultureInfo.InvariantCulture, "N({0},{1})", mean, variance) };
 
-			for(int i = 0; i < n; i++) {
-				double x = x0 + ((x1 - x0) * i / (n - 1));
-				double f = 1.0 / Math.Sqrt(2 * Math.PI * variance) * Math.Exp(-(x - mean) * (x - mean) / 2 / variance);
-				ls.Points.Add(new DataPoint(x, f));
-			}
+            for (int i = 0; i < n; i++)
+            {
+                double x = x0 + ((x1 - x0) * i / (n - 1));
+                double f = 1.0 / Math.Sqrt(2 * Math.PI * variance) * Math.Exp(-(x - mean) * (x - mean) / 2 / variance);
+                ls.Points.Add(new DataPoint(x, f));
+            }
 
-			return ls;
-		}
-	}
+            return ls;
+        }
+    }
 }

--- a/ExampleGenerator/Misc/Showcases.cs
+++ b/ExampleGenerator/Misc/Showcases.cs
@@ -1,65 +1,60 @@
-﻿namespace ExampleGenerator
-{
-    using System;
-    using System.Globalization;
+﻿namespace ExampleGenerator {
+	using System;
+	using System.Globalization;
 
-    using OxyPlot;
-    using OxyPlot.Axes;
-    using OxyPlot.Series;
+	using OxyPlot;
+	using OxyPlot.Axes;
+	using OxyPlot.Series;
 
-    public static class Showcases
-    {
-        [Export(@"Showcases\NormalDistribution")]
-        public static PlotModel LineSeries()
-        {
-            // http://en.wikipedia.org/wiki/Normal_distribution
-            var plot = new PlotModel
-                           {
-                               Title = "Normal distribution",
-                               Subtitle = "Probability density function",
-                               DefaultFont = "Arial",
-                               Culture = CultureInfo.InvariantCulture
-                           };
+	public static class Showcases {
+		[Export("Showcases/NormalDistribution")]
+		public static PlotModel LineSeries() {
+			// http://en.wikipedia.org/wiki/Normal_distribution
+			var plot = new PlotModel
+			{
+				Title = "Normal distribution",
+				Subtitle = "Probability density function",
+				DefaultFont = "Arial",
+				Culture = CultureInfo.InvariantCulture
+			};
 
-            plot.Axes.Add(
-                new LinearAxis
-                    {
-                        Position = AxisPosition.Left,
-                        Minimum = -0.05,
-                        Maximum = 1.05,
-                        MajorStep = 0.2,
-                        MinorStep = 0.05,
-                        TickStyle = TickStyle.Inside
-                    });
-            plot.Axes.Add(
-                new LinearAxis
-                    {
-                        Position = AxisPosition.Bottom,
-                        Minimum = -5.25,
-                        Maximum = 5.25,
-                        MajorStep = 1,
-                        MinorStep = 0.25,
-                        TickStyle = TickStyle.Inside
-                    });
-            plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 0.2));
-            plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 1));
-            plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 5));
-            plot.Series.Add(CreateNormalDistributionSeries(-5, 5, -2, 0.5));
-            return plot;
-        }
+			plot.Axes.Add(
+				new LinearAxis
+				{
+					Position = AxisPosition.Left,
+					Minimum = -0.05,
+					Maximum = 1.05,
+					MajorStep = 0.2,
+					MinorStep = 0.05,
+					TickStyle = TickStyle.Inside
+				});
+			plot.Axes.Add(
+				new LinearAxis
+				{
+					Position = AxisPosition.Bottom,
+					Minimum = -5.25,
+					Maximum = 5.25,
+					MajorStep = 1,
+					MinorStep = 0.25,
+					TickStyle = TickStyle.Inside
+				});
+			plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 0.2));
+			plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 1));
+			plot.Series.Add(CreateNormalDistributionSeries(-5, 5, 0, 5));
+			plot.Series.Add(CreateNormalDistributionSeries(-5, 5, -2, 0.5));
+			return plot;
+		}
 
-        private static DataPointSeries CreateNormalDistributionSeries(double x0, double x1, double mean, double variance, int n = 1001)
-        {
-            var ls = new LineSeries { Title = string.Format(CultureInfo.InvariantCulture, "N({0},{1})", mean, variance) };
+		private static DataPointSeries CreateNormalDistributionSeries(double x0, double x1, double mean, double variance, int n = 1001) {
+			var ls = new LineSeries { Title = string.Format(CultureInfo.InvariantCulture, "N({0},{1})", mean, variance) };
 
-            for (int i = 0; i < n; i++)
-            {
-                double x = x0 + ((x1 - x0) * i / (n - 1));
-                double f = 1.0 / Math.Sqrt(2 * Math.PI * variance) * Math.Exp(-(x - mean) * (x - mean) / 2 / variance);
-                ls.Points.Add(new DataPoint(x, f));
-            }
+			for(int i = 0; i < n; i++) {
+				double x = x0 + ((x1 - x0) * i / (n - 1));
+				double f = 1.0 / Math.Sqrt(2 * Math.PI * variance) * Math.Exp(-(x - mean) * (x - mean) / 2 / variance);
+				ls.Points.Add(new DataPoint(x, f));
+			}
 
-            return ls;
-        }
-    }
+			return ls;
+		}
+	}
 }

--- a/ExampleGenerator/Program.cs
+++ b/ExampleGenerator/Program.cs
@@ -25,117 +25,100 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace ExampleGenerator
-{
-    using System;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Reflection;
+namespace ExampleGenerator {
+	using System;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Reflection;
 
-    using OxyPlot;
-    using OxyPlot.WindowsForms;
+	using OxyPlot;
+	using OxyPlot.WindowsForms;
 
-    public static class Program
-    {
-        private static string pngOptimizer;
+	public static class Program {
+		private static string pngOptimizer;
 
-        public static string OutputDirectory { get; set; }
+		public static string OutputDirectory { get; set; }
 
-        public static bool ExportPng { get; set; }
+		public static bool ExportPng { get; set; }
 
-        public static bool ExportPdf { get; set; }
+		public static bool ExportPdf { get; set; }
 
-        public static bool ExportSvg { get; set; }
+		public static bool ExportSvg { get; set; }
 
-        public static void Main(string[] args)
-        {
-            pngOptimizer = Path.GetFullPath(@"TruePNG.exe");
+		public static void Main(string[] args) {
+			pngOptimizer = Path.GetFullPath(@"TruePNG.exe");
 
-            ExportPng = true;
-            ExportPdf = true;
-            ExportSvg = true;
-            OutputDirectory = @".";
-            if (args.Length > 0)
-            {
-                OutputDirectory = args[0];
-            }
+			ExportPng = true;
+			ExportPdf = true;
+			ExportSvg = true;
+			OutputDirectory = @".";
+			if(args.Length > 0) {
+				OutputDirectory = args[0];
+			}
 
-            foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
-            {
-                foreach (var method in type.GetMethods(BindingFlags.Static | BindingFlags.Public))
-                {
-                    var exportAttribute = method.GetCustomAttribute<ExportAttribute>();
-                    if (exportAttribute == null)
-                    {
-                        continue;
-                    }
+			foreach(var type in Assembly.GetExecutingAssembly().GetTypes()) {
+				foreach(var method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)) {
+					var exportAttribute = method.GetCustomAttribute<ExportAttribute>();
+					if(exportAttribute == null) {
+						continue;
+					}
 
-                    var model = (PlotModel)method.Invoke(null, null);
-                    Export(model, exportAttribute.Filename);
-                }
-            }
-        }
+					var model = (PlotModel)method.Invoke(null, null);
+					Export(model, exportAttribute.Filename.Replace('/', Path.DirectorySeparatorChar));
+				}
+			}
+		}
 
-        private static void Export(PlotModel model, string name)
-        {
-            var fileName = Path.Combine(OutputDirectory, name + ".png");
-            var directory = Path.GetDirectoryName(fileName) ?? ".";
+		private static void Export(PlotModel model, string name) {
+			var fileName = Path.Combine(OutputDirectory, name + ".png");
+			var directory = Path.GetDirectoryName(fileName) ?? ".";
             
-            if (!Directory.Exists(directory))
-            {
-                Directory.CreateDirectory(directory);
-            }
+			if(!Directory.Exists(directory)) {
+				Directory.CreateDirectory(directory);
+			}
 
-            if (ExportPng)
-            {
-                Console.WriteLine(fileName);
-                using (var stream = File.Create(fileName))
-                {
-                    var exporter = new PngExporter { Width = 600, Height = 400 };
-                    exporter.Export(model, stream);
-                }
+			if(ExportPng) {
+				Console.WriteLine(fileName);
+				using(var stream = File.Create(fileName)) {
+					var exporter = new PngExporter { Width = 600, Height = 400 };
+					exporter.Export(model, stream);
+				}
 
-                OptimizePng(fileName);
-            }
+				OptimizePng(fileName);
+			}
 
-            if (ExportPdf)
-            {
-                fileName = Path.ChangeExtension(fileName, ".pdf");
-                Console.WriteLine(fileName);
-                using (var stream = File.Create(fileName))
-                {
-                    var exporter = new PdfExporter { Width = 600d * 72 / 96, Height = 400d * 72 / 96 };
-                    exporter.Export(model, stream);
-                }
-            }
+			if(ExportPdf) {
+				fileName = Path.ChangeExtension(fileName, ".pdf");
+				Console.WriteLine(fileName);
+				using(var stream = File.Create(fileName)) {
+					var exporter = new PdfExporter { Width = 600d * 72 / 96, Height = 400d * 72 / 96 };
+					exporter.Export(model, stream);
+				}
+			}
 
-            if (ExportSvg)
-            {
-                fileName = Path.ChangeExtension(fileName, ".svg");
-                Console.WriteLine(fileName);
+			if(ExportSvg) {
+				fileName = Path.ChangeExtension(fileName, ".svg");
+				Console.WriteLine(fileName);
 
-                using (var stream = File.Create(fileName))
-                {
-                    using (var exporter = new OxyPlot.WindowsForms.SvgExporter { Width = 600, Height = 400, IsDocument = true })
-                    {
-                        exporter.Export(model, stream);
-                    }
-                }
-            }
-        }
+				using(var stream = File.Create(fileName)) {
+					using(var exporter = new OxyPlot.WindowsForms.SvgExporter { Width = 600, Height = 400, IsDocument = true }) {
+						exporter.Export(model, stream);
+					}
+				}
+			}
+		}
 
-        private static void OptimizePng(string pngFile)
-        {
-            // /o max : optimization level
-            // /nc : don't change ColorType and BitDepth
-            // /md keep pHYs : keep pHYs metadata
-            var psi = new ProcessStartInfo(pngOptimizer, pngFile + " /o max /nc /md keep pHYs")
-            {
-                CreateNoWindow = true,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
-            var p = Process.Start(psi);
-            p.WaitForExit();
-        }
-    }
+		private static void OptimizePng(string pngFile) {
+			// /o max : optimization level
+			// /nc : don't change ColorType and BitDepth
+			// /md keep pHYs : keep pHYs metadata
+			var psi = new ProcessStartInfo(pngOptimizer, pngFile + " /o max /nc /md keep pHYs")
+			{
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden
+			};
+			var p = Process.Start(psi);
+			p.WaitForExit();
+		}
+	}
 }

--- a/ExampleGenerator/Program.cs
+++ b/ExampleGenerator/Program.cs
@@ -35,7 +35,6 @@ namespace ExampleGenerator {
 	using OxyPlot.WindowsForms;
 
 	public static class Program {
-		private static string pngOptimizer;
 
 		public static string OutputDirectory { get; set; }
 
@@ -46,8 +45,6 @@ namespace ExampleGenerator {
 		public static bool ExportSvg { get; set; }
 
 		public static void Main(string[] args) {
-			pngOptimizer = Path.GetFullPath(@"TruePNG.exe");
-
 			ExportPng = true;
 			ExportPdf = true;
 			ExportSvg = true;
@@ -108,11 +105,23 @@ namespace ExampleGenerator {
 			}
 		}
 
+
+		/* PNG Optimization */
+
 		private static void OptimizePng(string pngFile) {
+			if(Environment.OSVersion.Platform == PlatformID.Unix) {
+				OptimizePngWithOptiPNG(pngFile);
+			} else {
+				OptimizePngWithTruePNG(pngFile);
+			}
+		}
+
+		private static void OptimizePngWithTruePNG(string pngFile) {
+			var truePngExecutable = Path.GetFullPath("TruePNG.exe");
 			// /o max : optimization level
 			// /nc : don't change ColorType and BitDepth
 			// /md keep pHYs : keep pHYs metadata
-			var psi = new ProcessStartInfo(pngOptimizer, pngFile + " /o max /nc /md keep pHYs")
+			var psi = new ProcessStartInfo(truePngExecutable, pngFile + " /o max /nc /md keep pHYs")
 			{
 				CreateNoWindow = true,
 				WindowStyle = ProcessWindowStyle.Hidden
@@ -120,5 +129,16 @@ namespace ExampleGenerator {
 			var p = Process.Start(psi);
 			p.WaitForExit();
 		}
+
+		private static void OptimizePngWithOptiPNG(string pngFile) {
+			var psi = new ProcessStartInfo("optipng", "-o7 " + pngFile)
+			{
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden
+			};
+			var p = Process.Start(psi);
+			p.WaitForExit();
+		}
+
 	}
 }

--- a/ExampleGenerator/Program.cs
+++ b/ExampleGenerator/Program.cs
@@ -27,126 +27,148 @@
 using System.Threading.Tasks;
 using System.Collections.Generic;
 
-namespace ExampleGenerator {
-	using System;
-	using System.Diagnostics;
-	using System.IO;
-	using System.Reflection;
+namespace ExampleGenerator
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Reflection;
 
-	using OxyPlot;
-	using OxyPlot.WindowsForms;
+    using OxyPlot;
+    using OxyPlot.WindowsForms;
 
-	public static class Program {
+    public static class Program
+    {
 
-		public static string OutputDirectory { get; set; }
+        public static string OutputDirectory { get; set; }
 
-		public static bool ExportPng { get; set; }
+        public static bool ExportPng { get; set; }
 
-		public static bool ExportPdf { get; set; }
+        public static bool ExportPdf { get; set; }
 
-		public static bool ExportSvg { get; set; }
+        public static bool ExportSvg { get; set; }
 
-		public static void Main(string[] args) {
-			ExportPng = true;
-			ExportPdf = true;
-			ExportSvg = true;
-			OutputDirectory = @".";
-			if(args.Length > 0) {
-				OutputDirectory = args[0];
-			}
+        public static void Main(string[] args)
+        {
+            ExportPng = true;
+            ExportPdf = true;
+            ExportSvg = true;
+            OutputDirectory = @".";
+            if (args.Length > 0)
+            {
+                OutputDirectory = args[0];
+            }
 
-			var exportTasks = new List<Task>();
+            var exportTasks = new List<Task>();
 
-			foreach(var type in Assembly.GetExecutingAssembly().GetTypes()) {
-				foreach(var method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)) {
-					var exportAttribute = method.GetCustomAttribute<ExportAttribute>();
-					if(exportAttribute == null) {
-						continue;
-					}
+            foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
+            {
+                foreach (var method in type.GetMethods(BindingFlags.Static | BindingFlags.Public))
+                {
+                    var exportAttribute = method.GetCustomAttribute<ExportAttribute>();
+                    if (exportAttribute == null)
+                    {
+                        continue;
+                    }
 
-					var model = (PlotModel)method.Invoke(null, null);
-					var exportTask = Export(model, exportAttribute.Filename.Replace('/', Path.DirectorySeparatorChar));
-					exportTasks.Add(exportTask);
-				}
-			}
+                    var model = (PlotModel)method.Invoke(null, null);
+                    var exportTask = Export(model, exportAttribute.Filename.Replace('/', Path.DirectorySeparatorChar));
+                    exportTasks.Add(exportTask);
+                }
+            }
 
-			//Wait for exports to finish
-			Task.WaitAll(exportTasks.ToArray());
-		}
+            //Wait for exports to finish
+            Task.WaitAll(exportTasks.ToArray());
+        }
 
-		private static async Task Export(PlotModel model, string name) {
-			var fileName = Path.Combine(OutputDirectory, name + ".png");
-			var directory = Path.GetDirectoryName(fileName) ?? ".";
+        private static async Task Export(PlotModel model, string name)
+        {
+            var fileName = Path.Combine(OutputDirectory, name + ".png");
+            var directory = Path.GetDirectoryName(fileName) ?? ".";
             
-			if(!Directory.Exists(directory)) {
-				Directory.CreateDirectory(directory);
-			}
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
 
-			if(ExportPng) {
-				Console.WriteLine(fileName);
-				using(var stream = File.Create(fileName)) {
-					var exporter = new PngExporter { Width = 600, Height = 400 };
-					exporter.Export(model, stream);
-				}
+            if (ExportPng)
+            {
+                Console.WriteLine(fileName);
+                using (var stream = File.Create(fileName))
+                {
+                    var exporter = new PngExporter { Width = 600, Height = 400 };
+                    exporter.Export(model, stream);
+                }
 
-				await OptimizePng(fileName);
-			}
+                await OptimizePng(fileName);
+            }
 
-			if(ExportPdf) {
-				fileName = Path.ChangeExtension(fileName, ".pdf");
-				Console.WriteLine(fileName);
-				using(var stream = File.Create(fileName)) {
-					var exporter = new PdfExporter { Width = 600d * 72 / 96, Height = 400d * 72 / 96 };
-					exporter.Export(model, stream);
-				}
-			}
+            if (ExportPdf)
+            {
+                fileName = Path.ChangeExtension(fileName, ".pdf");
+                Console.WriteLine(fileName);
+                using (var stream = File.Create(fileName))
+                {
+                    var exporter = new PdfExporter { Width = 600d * 72 / 96, Height = 400d * 72 / 96 };
+                    exporter.Export(model, stream);
+                }
+            }
 
-			if(ExportSvg) {
-				fileName = Path.ChangeExtension(fileName, ".svg");
-				Console.WriteLine(fileName);
+            if (ExportSvg)
+            {
+                fileName = Path.ChangeExtension(fileName, ".svg");
+                Console.WriteLine(fileName);
 
-				using(var stream = File.Create(fileName)) {
-					using(var exporter = new OxyPlot.WindowsForms.SvgExporter { Width = 600, Height = 400, IsDocument = true }) {
-						exporter.Export(model, stream);
-					}
-				}
-			}
-		}
+                using (var stream = File.Create(fileName))
+                {
+                    using (var exporter = new OxyPlot.WindowsForms.SvgExporter { Width = 600, Height = 400, IsDocument = true })
+                    {
+                        exporter.Export(model, stream);
+                    }
+                }
+            }
+        }
 
 
-		/* PNG Optimization */
+        /* PNG Optimization */
 
-		private static async Task OptimizePng(string pngFile) {
-			if(Environment.OSVersion.Platform == PlatformID.Unix) {
-				await OptimizePngWithOptiPNG(pngFile);
-			} else {
-				await OptimizePngWithTruePNG(pngFile);
-			}
-		}
+        private static async Task OptimizePng(string pngFile)
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                await OptimizePngWithOptiPNG(pngFile);
+            }
+            else
+            {
+                await OptimizePngWithTruePNG(pngFile);
+            }
+        }
 
-		private static async Task OptimizePngWithTruePNG(string pngFile) {
-			var truePngExecutable = Path.GetFullPath("TruePNG.exe");
-			// /o max : optimization level
-			// /nc : don't change ColorType and BitDepth
-			// /md keep pHYs : keep pHYs metadata
-			var psi = new ProcessStartInfo(truePngExecutable, pngFile + " /o max /nc /md keep pHYs")
-			{
-				CreateNoWindow = true,
-				WindowStyle = ProcessWindowStyle.Hidden
-			};
-			var p = Process.Start(psi);
-			await Task.Run(() => p.WaitForExit());
-		}
+        private static async Task OptimizePngWithTruePNG(string pngFile)
+        {
+            var truePngExecutable = Path.GetFullPath("TruePNG.exe");
+            // /o max : optimization level
+            // /nc : don't change ColorType and BitDepth
+            // /md keep pHYs : keep pHYs metadata
+            var psi = new ProcessStartInfo(truePngExecutable, pngFile + " /o max /nc /md keep pHYs")
+            {
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden
+            };
+            var p = Process.Start(psi);
+            await Task.Run(() => p.WaitForExit());
+        }
 
-		private static async Task OptimizePngWithOptiPNG(string pngFile) {
-			var psi = new ProcessStartInfo("optipng", "-o7 " + pngFile)
-			{
-				CreateNoWindow = true,
-				WindowStyle = ProcessWindowStyle.Hidden
-			};
-			var p = Process.Start(psi);
-			await Task.Run(() => p.WaitForExit());
-		}
+        private static async Task OptimizePngWithOptiPNG(string pngFile)
+        {
+            var psi = new ProcessStartInfo("optipng", "-o7 " + pngFile)
+            {
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden
+            };
+            var p = Process.Start(psi);
+            await Task.Run(() => p.WaitForExit());
+        }
 
-	}
+    }
 }

--- a/ExampleGenerator/Series/BarSeriesExamples.cs
+++ b/ExampleGenerator/Series/BarSeriesExamples.cs
@@ -2,97 +2,102 @@
 using System.Linq;
 using System.Collections.Generic;
 
-namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Axes;
-	using OxyPlot.Series;
+namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Axes;
+    using OxyPlot.Series;
 
-	public class BarSeriesExamples {
-
-
-		[Export("Series/BarSeries")]
-		public static PlotModel BarSeries() {
-
-			var model = new PlotModel{ Title = "Cake Type Popularity" };
-
-			//generate a random percentage distribution between the 5
-			//cake-types (see axis below)
-			var rand = new Random();
-			double[] cakePopularity = new double[5];
-			for(int i = 0; i < 5; ++i) {
-				cakePopularity[i] = rand.NextDouble();
-			}
-			var sum = cakePopularity.Sum();
-
-			var barSeries = new BarSeries
-			{
-				ItemsSource = new List<BarItem>(new[]
-				{
-					new BarItem{ Value = (cakePopularity[0] / sum * 100) },
-					new BarItem{ Value = (cakePopularity[1] / sum * 100) },
-					new BarItem{ Value = (cakePopularity[2] / sum * 100) },
-					new BarItem{ Value = (cakePopularity[3] / sum * 100) },
-					new BarItem{ Value = (cakePopularity[4] / sum * 100) }
-				}),
-				LabelPlacement = LabelPlacement.Inside,
-				LabelFormatString = "{0:.00}%"
-			};
-			model.Series.Add(barSeries);
-
-			model.Axes.Add(new CategoryAxis
-			{
-				Position = AxisPosition.Left,
-				Key = "CakeAxis",
-				ItemsSource = new[]
-				{
-					"Apple cake",
-					"Baumkuchen",
-					"Bundt Cake",
-					"Chocolate cake",
-					"Carrot cake"
-				}
-			});
-
-			return model;
-		}
+    public class BarSeriesExamples
+    {
 
 
+        [Export("Series/BarSeries")]
+        public static PlotModel BarSeries()
+        {
 
-		[Export("Series/BarSeries_grouped")]
-		public static PlotModel BarSeries_grouped() {
-			var model = new PlotModel
-			{
-				Title = "BarSeries",
-				LegendPlacement = LegendPlacement.Outside,
-				LegendPosition = LegendPosition.BottomCenter,
-				LegendOrientation = LegendOrientation.Horizontal,
-				LegendBorderThickness = 0
-			};
+            var model = new PlotModel{ Title = "Cake Type Popularity" };
 
-			var s1 = new BarSeries { Title = "Series 1", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
-			s1.Items.Add(new BarItem { Value = 25 });
-			s1.Items.Add(new BarItem { Value = 137 });
-			s1.Items.Add(new BarItem { Value = 18 });
-			s1.Items.Add(new BarItem { Value = 40 });
+            //generate a random percentage distribution between the 5
+            //cake-types (see axis below)
+            var rand = new Random();
+            double[] cakePopularity = new double[5];
+            for (int i = 0; i < 5; ++i)
+            {
+                cakePopularity[i] = rand.NextDouble();
+            }
+            var sum = cakePopularity.Sum();
 
-			var s2 = new BarSeries { Title = "Series 2", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
-			s2.Items.Add(new BarItem { Value = 12 });
-			s2.Items.Add(new BarItem { Value = 14 });
-			s2.Items.Add(new BarItem { Value = 120 });
-			s2.Items.Add(new BarItem { Value = 26 });
+            var barSeries = new BarSeries
+            {
+                ItemsSource = new List<BarItem>(new[]
+                    {
+                        new BarItem{ Value = (cakePopularity[0] / sum * 100) },
+                        new BarItem{ Value = (cakePopularity[1] / sum * 100) },
+                        new BarItem{ Value = (cakePopularity[2] / sum * 100) },
+                        new BarItem{ Value = (cakePopularity[3] / sum * 100) },
+                        new BarItem{ Value = (cakePopularity[4] / sum * 100) }
+                    }),
+                LabelPlacement = LabelPlacement.Inside,
+                LabelFormatString = "{0:.00}%"
+            };
+            model.Series.Add(barSeries);
 
-			var categoryAxis = new CategoryAxis { Position = AxisPosition.Left };
-			categoryAxis.Labels.Add("Category A");
-			categoryAxis.Labels.Add("Category B");
-			categoryAxis.Labels.Add("Category C");
-			categoryAxis.Labels.Add("Category D");
-			var valueAxis = new LinearAxis { Position = AxisPosition.Bottom, MinimumPadding = 0, MaximumPadding = 0.06, AbsoluteMinimum = 0 };
-			model.Series.Add(s1);
-			model.Series.Add(s2);
-			model.Axes.Add(categoryAxis);
-			model.Axes.Add(valueAxis);
-			return model;
-		}
+            model.Axes.Add(new CategoryAxis
+                {
+                    Position = AxisPosition.Left,
+                    Key = "CakeAxis",
+                    ItemsSource = new[]
+                    {
+                        "Apple cake",
+                        "Baumkuchen",
+                        "Bundt Cake",
+                        "Chocolate cake",
+                        "Carrot cake"
+                    }
+                });
 
-	}
+            return model;
+        }
+
+
+
+        [Export("Series/BarSeries_grouped")]
+        public static PlotModel BarSeries_grouped()
+        {
+            var model = new PlotModel
+            {
+                Title = "BarSeries",
+                LegendPlacement = LegendPlacement.Outside,
+                LegendPosition = LegendPosition.BottomCenter,
+                LegendOrientation = LegendOrientation.Horizontal,
+                LegendBorderThickness = 0
+            };
+
+            var s1 = new BarSeries { Title = "Series 1", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+            s1.Items.Add(new BarItem { Value = 25 });
+            s1.Items.Add(new BarItem { Value = 137 });
+            s1.Items.Add(new BarItem { Value = 18 });
+            s1.Items.Add(new BarItem { Value = 40 });
+
+            var s2 = new BarSeries { Title = "Series 2", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+            s2.Items.Add(new BarItem { Value = 12 });
+            s2.Items.Add(new BarItem { Value = 14 });
+            s2.Items.Add(new BarItem { Value = 120 });
+            s2.Items.Add(new BarItem { Value = 26 });
+
+            var categoryAxis = new CategoryAxis { Position = AxisPosition.Left };
+            categoryAxis.Labels.Add("Category A");
+            categoryAxis.Labels.Add("Category B");
+            categoryAxis.Labels.Add("Category C");
+            categoryAxis.Labels.Add("Category D");
+            var valueAxis = new LinearAxis { Position = AxisPosition.Bottom, MinimumPadding = 0, MaximumPadding = 0.06, AbsoluteMinimum = 0 };
+            model.Series.Add(s1);
+            model.Series.Add(s2);
+            model.Axes.Add(categoryAxis);
+            model.Axes.Add(valueAxis);
+            return model;
+        }
+
+    }
 }

--- a/ExampleGenerator/Series/BarSeriesExamples.cs
+++ b/ExampleGenerator/Series/BarSeriesExamples.cs
@@ -2,19 +2,16 @@
 using System.Linq;
 using System.Collections.Generic;
 
-namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Axes;
-    using OxyPlot.Series;
+namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Axes;
+	using OxyPlot.Series;
 
-    public class BarSeriesExamples
-    {
+	public class BarSeriesExamples {
 
 
-		[Export(@"Series\BarSeries")]
-		public static PlotModel BarSeries()
-		{
+		[Export("Series/BarSeries")]
+		public static PlotModel BarSeries() {
 
 			var model = new PlotModel{ Title = "Cake Type Popularity" };
 
@@ -61,42 +58,41 @@ namespace ExampleGenerator
 
 
 
-        [Export(@"Series\BarSeries_grouped")]
-		public static PlotModel BarSeries_grouped()
-        {
-            var model = new PlotModel
-                            {
-                                Title = "BarSeries",
-                                LegendPlacement = LegendPlacement.Outside,
-                                LegendPosition = LegendPosition.BottomCenter,
-                                LegendOrientation = LegendOrientation.Horizontal,
-                                LegendBorderThickness = 0
-                            };
+		[Export("Series/BarSeries_grouped")]
+		public static PlotModel BarSeries_grouped() {
+			var model = new PlotModel
+			{
+				Title = "BarSeries",
+				LegendPlacement = LegendPlacement.Outside,
+				LegendPosition = LegendPosition.BottomCenter,
+				LegendOrientation = LegendOrientation.Horizontal,
+				LegendBorderThickness = 0
+			};
 
-            var s1 = new BarSeries { Title = "Series 1", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
-            s1.Items.Add(new BarItem { Value = 25 });
-            s1.Items.Add(new BarItem { Value = 137 });
-            s1.Items.Add(new BarItem { Value = 18 });
-            s1.Items.Add(new BarItem { Value = 40 });
+			var s1 = new BarSeries { Title = "Series 1", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+			s1.Items.Add(new BarItem { Value = 25 });
+			s1.Items.Add(new BarItem { Value = 137 });
+			s1.Items.Add(new BarItem { Value = 18 });
+			s1.Items.Add(new BarItem { Value = 40 });
 
-            var s2 = new BarSeries { Title = "Series 2", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
-            s2.Items.Add(new BarItem { Value = 12 });
-            s2.Items.Add(new BarItem { Value = 14 });
-            s2.Items.Add(new BarItem { Value = 120 });
-            s2.Items.Add(new BarItem { Value = 26 });
+			var s2 = new BarSeries { Title = "Series 2", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+			s2.Items.Add(new BarItem { Value = 12 });
+			s2.Items.Add(new BarItem { Value = 14 });
+			s2.Items.Add(new BarItem { Value = 120 });
+			s2.Items.Add(new BarItem { Value = 26 });
 
-            var categoryAxis = new CategoryAxis { Position = AxisPosition.Left };
-            categoryAxis.Labels.Add("Category A");
-            categoryAxis.Labels.Add("Category B");
-            categoryAxis.Labels.Add("Category C");
-            categoryAxis.Labels.Add("Category D");
-            var valueAxis = new LinearAxis { Position = AxisPosition.Bottom, MinimumPadding = 0, MaximumPadding = 0.06, AbsoluteMinimum = 0 };
-            model.Series.Add(s1);
-            model.Series.Add(s2);
-            model.Axes.Add(categoryAxis);
-            model.Axes.Add(valueAxis);
-            return model;
-        }
+			var categoryAxis = new CategoryAxis { Position = AxisPosition.Left };
+			categoryAxis.Labels.Add("Category A");
+			categoryAxis.Labels.Add("Category B");
+			categoryAxis.Labels.Add("Category C");
+			categoryAxis.Labels.Add("Category D");
+			var valueAxis = new LinearAxis { Position = AxisPosition.Bottom, MinimumPadding = 0, MaximumPadding = 0.06, AbsoluteMinimum = 0 };
+			model.Series.Add(s1);
+			model.Series.Add(s2);
+			model.Axes.Add(categoryAxis);
+			model.Axes.Add(valueAxis);
+			return model;
+		}
 
-    }
+	}
 }

--- a/ExampleGenerator/Series/ColumnSeriesExamples.cs
+++ b/ExampleGenerator/Series/ColumnSeriesExamples.cs
@@ -1,43 +1,46 @@
-namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Axes;
-	using OxyPlot.Series;
+namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Axes;
+    using OxyPlot.Series;
 
-	public class ColumnSeriesExamples {
-		[Export("Series/ColumnSeries")]
-		public static PlotModel ColumnSeries() {
-			var model = new PlotModel
-			{
-				Title = "ColumnSeries",
-				LegendPlacement = LegendPlacement.Outside,
-				LegendPosition = LegendPosition.BottomCenter,
-				LegendOrientation = LegendOrientation.Horizontal,
-				LegendBorderThickness = 0
-			};
+    public class ColumnSeriesExamples
+    {
+        [Export("Series/ColumnSeries")]
+        public static PlotModel ColumnSeries()
+        {
+            var model = new PlotModel
+            {
+                Title = "ColumnSeries",
+                LegendPlacement = LegendPlacement.Outside,
+                LegendPosition = LegendPosition.BottomCenter,
+                LegendOrientation = LegendOrientation.Horizontal,
+                LegendBorderThickness = 0
+            };
 
-			var s1 = new ColumnSeries { Title = "Series 1", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
-			s1.Items.Add(new ColumnItem { Value = 25 });
-			s1.Items.Add(new ColumnItem { Value = 137 });
-			s1.Items.Add(new ColumnItem { Value = 18 });
-			s1.Items.Add(new ColumnItem { Value = 40 });
+            var s1 = new ColumnSeries { Title = "Series 1", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+            s1.Items.Add(new ColumnItem { Value = 25 });
+            s1.Items.Add(new ColumnItem { Value = 137 });
+            s1.Items.Add(new ColumnItem { Value = 18 });
+            s1.Items.Add(new ColumnItem { Value = 40 });
 
-			var s2 = new ColumnSeries { Title = "Series 2", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
-			s2.Items.Add(new ColumnItem { Value = 12 });
-			s2.Items.Add(new ColumnItem { Value = 14 });
-			s2.Items.Add(new ColumnItem { Value = 120 });
-			s2.Items.Add(new ColumnItem { Value = 26 });
+            var s2 = new ColumnSeries { Title = "Series 2", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+            s2.Items.Add(new ColumnItem { Value = 12 });
+            s2.Items.Add(new ColumnItem { Value = 14 });
+            s2.Items.Add(new ColumnItem { Value = 120 });
+            s2.Items.Add(new ColumnItem { Value = 26 });
 
-			var categoryAxis = new CategoryAxis { Position = AxisPosition.Bottom };
-			categoryAxis.Labels.Add("Category A");
-			categoryAxis.Labels.Add("Category B");
-			categoryAxis.Labels.Add("Category C");
-			categoryAxis.Labels.Add("Category D");
-			var valueAxis = new LinearAxis { Position = AxisPosition.Left, MinimumPadding = 0, MaximumPadding = 0.06, AbsoluteMinimum = 0 };
-			model.Series.Add(s1);
-			model.Series.Add(s2);
-			model.Axes.Add(categoryAxis);
-			model.Axes.Add(valueAxis);
-			return model;
-		}
-	}
+            var categoryAxis = new CategoryAxis { Position = AxisPosition.Bottom };
+            categoryAxis.Labels.Add("Category A");
+            categoryAxis.Labels.Add("Category B");
+            categoryAxis.Labels.Add("Category C");
+            categoryAxis.Labels.Add("Category D");
+            var valueAxis = new LinearAxis { Position = AxisPosition.Left, MinimumPadding = 0, MaximumPadding = 0.06, AbsoluteMinimum = 0 };
+            model.Series.Add(s1);
+            model.Series.Add(s2);
+            model.Axes.Add(categoryAxis);
+            model.Axes.Add(valueAxis);
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Series/ColumnSeriesExamples.cs
+++ b/ExampleGenerator/Series/ColumnSeriesExamples.cs
@@ -1,46 +1,43 @@
-namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Axes;
-    using OxyPlot.Series;
+namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Axes;
+	using OxyPlot.Series;
 
-    public class ColumnSeriesExamples
-    {
-        [Export(@"Series\ColumnSeries")]
-        public static PlotModel ColumnSeries()
-        {
-            var model = new PlotModel
-                            {
-                                Title = "ColumnSeries",
-                                LegendPlacement = LegendPlacement.Outside,
-                                LegendPosition = LegendPosition.BottomCenter,
-                                LegendOrientation = LegendOrientation.Horizontal,
-                                LegendBorderThickness = 0
-                            };
+	public class ColumnSeriesExamples {
+		[Export("Series/ColumnSeries")]
+		public static PlotModel ColumnSeries() {
+			var model = new PlotModel
+			{
+				Title = "ColumnSeries",
+				LegendPlacement = LegendPlacement.Outside,
+				LegendPosition = LegendPosition.BottomCenter,
+				LegendOrientation = LegendOrientation.Horizontal,
+				LegendBorderThickness = 0
+			};
 
-            var s1 = new ColumnSeries { Title = "Series 1", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
-            s1.Items.Add(new ColumnItem { Value = 25 });
-            s1.Items.Add(new ColumnItem { Value = 137 });
-            s1.Items.Add(new ColumnItem { Value = 18 });
-            s1.Items.Add(new ColumnItem { Value = 40 });
+			var s1 = new ColumnSeries { Title = "Series 1", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+			s1.Items.Add(new ColumnItem { Value = 25 });
+			s1.Items.Add(new ColumnItem { Value = 137 });
+			s1.Items.Add(new ColumnItem { Value = 18 });
+			s1.Items.Add(new ColumnItem { Value = 40 });
 
-            var s2 = new ColumnSeries { Title = "Series 2", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
-            s2.Items.Add(new ColumnItem { Value = 12 });
-            s2.Items.Add(new ColumnItem { Value = 14 });
-            s2.Items.Add(new ColumnItem { Value = 120 });
-            s2.Items.Add(new ColumnItem { Value = 26 });
+			var s2 = new ColumnSeries { Title = "Series 2", StrokeColor = OxyColors.Black, StrokeThickness = 1 };
+			s2.Items.Add(new ColumnItem { Value = 12 });
+			s2.Items.Add(new ColumnItem { Value = 14 });
+			s2.Items.Add(new ColumnItem { Value = 120 });
+			s2.Items.Add(new ColumnItem { Value = 26 });
 
-            var categoryAxis = new CategoryAxis { Position = AxisPosition.Bottom };
-            categoryAxis.Labels.Add("Category A");
-            categoryAxis.Labels.Add("Category B");
-            categoryAxis.Labels.Add("Category C");
-            categoryAxis.Labels.Add("Category D");
-            var valueAxis = new LinearAxis { Position = AxisPosition.Left, MinimumPadding = 0, MaximumPadding = 0.06, AbsoluteMinimum = 0 };
-            model.Series.Add(s1);
-            model.Series.Add(s2);
-            model.Axes.Add(categoryAxis);
-            model.Axes.Add(valueAxis);
-            return model;
-        }
-    }
+			var categoryAxis = new CategoryAxis { Position = AxisPosition.Bottom };
+			categoryAxis.Labels.Add("Category A");
+			categoryAxis.Labels.Add("Category B");
+			categoryAxis.Labels.Add("Category C");
+			categoryAxis.Labels.Add("Category D");
+			var valueAxis = new LinearAxis { Position = AxisPosition.Left, MinimumPadding = 0, MaximumPadding = 0.06, AbsoluteMinimum = 0 };
+			model.Series.Add(s1);
+			model.Series.Add(s2);
+			model.Axes.Add(categoryAxis);
+			model.Axes.Add(valueAxis);
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Series/ContourSeriesExamples.cs
+++ b/ExampleGenerator/Series/ContourSeriesExamples.cs
@@ -1,36 +1,33 @@
-﻿namespace ExampleGenerator
-{
-    using System;
+﻿namespace ExampleGenerator {
+	using System;
 
-    using OxyPlot;
-    using OxyPlot.Series;
+	using OxyPlot;
+	using OxyPlot.Series;
 
-    [Export(@"Series\ContourSeries")]
-    public class ContourSeriesExamples
-    {
-        public static PlotModel ContourSeries()
-        {
-            var model = new PlotModel { Title = "ContourSeries" };
-            double x0 = -3.1;
-            double x1 = 3.1;
-            double y0 = -3;
-            double y1 = 3;
-            Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
-            var xx = ArrayBuilder.CreateVector(x0, x1, 100);
-            var yy = ArrayBuilder.CreateVector(y0, y1, 100);
-            var peaksData = ArrayBuilder.Evaluate(peaks, xx, yy);
+	[Export("Series/ContourSeries")]
+	public class ContourSeriesExamples {
+		public static PlotModel ContourSeries() {
+			var model = new PlotModel { Title = "ContourSeries" };
+			double x0 = -3.1;
+			double x1 = 3.1;
+			double y0 = -3;
+			double y1 = 3;
+			Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
+			var xx = ArrayBuilder.CreateVector(x0, x1, 100);
+			var yy = ArrayBuilder.CreateVector(y0, y1, 100);
+			var peaksData = ArrayBuilder.Evaluate(peaks, xx, yy);
 
-            var cs = new ContourSeries
-            {
-                Color = OxyColors.Black,
-                LabelBackground = OxyColors.White,
-                ColumnCoordinates = yy,
-                RowCoordinates = xx,
-                Data = peaksData
-            };
-            model.Series.Add(cs);
+			var cs = new ContourSeries
+			{
+				Color = OxyColors.Black,
+				LabelBackground = OxyColors.White,
+				ColumnCoordinates = yy,
+				RowCoordinates = xx,
+				Data = peaksData
+			};
+			model.Series.Add(cs);
 
-            return model;
-        }
-    }
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Series/ContourSeriesExamples.cs
+++ b/ExampleGenerator/Series/ContourSeriesExamples.cs
@@ -1,33 +1,36 @@
-﻿namespace ExampleGenerator {
-	using System;
+﻿namespace ExampleGenerator
+{
+    using System;
 
-	using OxyPlot;
-	using OxyPlot.Series;
+    using OxyPlot;
+    using OxyPlot.Series;
 
-	[Export("Series/ContourSeries")]
-	public class ContourSeriesExamples {
-		public static PlotModel ContourSeries() {
-			var model = new PlotModel { Title = "ContourSeries" };
-			double x0 = -3.1;
-			double x1 = 3.1;
-			double y0 = -3;
-			double y1 = 3;
-			Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
-			var xx = ArrayBuilder.CreateVector(x0, x1, 100);
-			var yy = ArrayBuilder.CreateVector(y0, y1, 100);
-			var peaksData = ArrayBuilder.Evaluate(peaks, xx, yy);
+    [Export("Series/ContourSeries")]
+    public class ContourSeriesExamples
+    {
+        public static PlotModel ContourSeries()
+        {
+            var model = new PlotModel { Title = "ContourSeries" };
+            double x0 = -3.1;
+            double x1 = 3.1;
+            double y0 = -3;
+            double y1 = 3;
+            Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
+            var xx = ArrayBuilder.CreateVector(x0, x1, 100);
+            var yy = ArrayBuilder.CreateVector(y0, y1, 100);
+            var peaksData = ArrayBuilder.Evaluate(peaks, xx, yy);
 
-			var cs = new ContourSeries
-			{
-				Color = OxyColors.Black,
-				LabelBackground = OxyColors.White,
-				ColumnCoordinates = yy,
-				RowCoordinates = xx,
-				Data = peaksData
-			};
-			model.Series.Add(cs);
+            var cs = new ContourSeries
+            {
+                Color = OxyColors.Black,
+                LabelBackground = OxyColors.White,
+                ColumnCoordinates = yy,
+                RowCoordinates = xx,
+                Data = peaksData
+            };
+            model.Series.Add(cs);
 
-			return model;
-		}
-	}
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Series/FunctionSeriesExamples.cs
+++ b/ExampleGenerator/Series/FunctionSeriesExamples.cs
@@ -1,29 +1,32 @@
 ﻿using System;
 
-namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Axes;
-	using OxyPlot.Series;
+namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Axes;
+    using OxyPlot.Series;
 
-	public class FunctionSeriesExamples {
-		[Export("Series/FunctionSeries")]
-		public static PlotModel FunctionSeries() {
-			var model = new PlotModel{ Title = "Fun with Bats" };
+    public class FunctionSeriesExamples
+    {
+        [Export("Series/FunctionSeries")]
+        public static PlotModel FunctionSeries()
+        {
+            var model = new PlotModel{ Title = "Fun with Bats" };
 
-			Func<double, double> batFn1 = (x) => 2 * Math.Sqrt(-Math.Abs(Math.Abs(x) - 1) * Math.Abs(3 - Math.Abs(x)) / ((Math.Abs(x) - 1) * (3 - Math.Abs(x)))) * (1 + Math.Abs(Math.Abs(x) - 3) / (Math.Abs(x) - 3)) * Math.Sqrt(1 - Math.Pow((x / 7), 2)) + (5 + 0.97 * (Math.Abs(x - 0.5) + Math.Abs(x + 0.5)) - 3 * (Math.Abs(x - 0.75) + Math.Abs(x + 0.75))) * (1 + Math.Abs(1 - Math.Abs(x)) / (1 - Math.Abs(x)));
-			Func<double, double> batFn2 = (x) => -3 * Math.Sqrt(1 - Math.Pow((x / 7), 2)) * Math.Sqrt(Math.Abs(Math.Abs(x) - 4) / (Math.Abs(x) - 4));
-			Func<double, double> batFn3 = (x) => Math.Abs(x / 2) - 0.0913722 * (Math.Pow(x, 2)) - 3 + Math.Sqrt(1 - Math.Pow((Math.Abs(Math.Abs(x) - 2) - 1), 2));
-			Func<double, double> batFn4 = (x) => (2.71052 + (1.5 - .5 * Math.Abs(x)) - 1.35526 * Math.Sqrt(4 - Math.Pow((Math.Abs(x) - 1), 2))) * Math.Sqrt(Math.Abs(Math.Abs(x) - 1) / (Math.Abs(x) - 1)) + 0.9;
+            Func<double, double> batFn1 = (x) => 2 * Math.Sqrt(-Math.Abs(Math.Abs(x) - 1) * Math.Abs(3 - Math.Abs(x)) / ((Math.Abs(x) - 1) * (3 - Math.Abs(x)))) * (1 + Math.Abs(Math.Abs(x) - 3) / (Math.Abs(x) - 3)) * Math.Sqrt(1 - Math.Pow((x / 7), 2)) + (5 + 0.97 * (Math.Abs(x - 0.5) + Math.Abs(x + 0.5)) - 3 * (Math.Abs(x - 0.75) + Math.Abs(x + 0.75))) * (1 + Math.Abs(1 - Math.Abs(x)) / (1 - Math.Abs(x)));
+            Func<double, double> batFn2 = (x) => -3 * Math.Sqrt(1 - Math.Pow((x / 7), 2)) * Math.Sqrt(Math.Abs(Math.Abs(x) - 4) / (Math.Abs(x) - 4));
+            Func<double, double> batFn3 = (x) => Math.Abs(x / 2) - 0.0913722 * (Math.Pow(x, 2)) - 3 + Math.Sqrt(1 - Math.Pow((Math.Abs(Math.Abs(x) - 2) - 1), 2));
+            Func<double, double> batFn4 = (x) => (2.71052 + (1.5 - .5 * Math.Abs(x)) - 1.35526 * Math.Sqrt(4 - Math.Pow((Math.Abs(x) - 1), 2))) * Math.Sqrt(Math.Abs(Math.Abs(x) - 1) / (Math.Abs(x) - 1)) + 0.9;
 
-			model.Series.Add(new FunctionSeries(batFn1, -8, 8, 0.0001));
-			model.Series.Add(new FunctionSeries(batFn2, -8, 8, 0.0001));
-			model.Series.Add(new FunctionSeries(batFn3, -8, 8, 0.0001));
-			model.Series.Add(new FunctionSeries(batFn4, -8, 8, 0.0001));
+            model.Series.Add(new FunctionSeries(batFn1, -8, 8, 0.0001));
+            model.Series.Add(new FunctionSeries(batFn2, -8, 8, 0.0001));
+            model.Series.Add(new FunctionSeries(batFn3, -8, 8, 0.0001));
+            model.Series.Add(new FunctionSeries(batFn4, -8, 8, 0.0001));
 
-			model.Axes.Add(new LinearAxis{ Position = AxisPosition.Bottom, MaximumPadding = 0.1, MinimumPadding = 0.1 });
-			model.Axes.Add(new LinearAxis{ Position = AxisPosition.Left, MaximumPadding = 0.1, MinimumPadding = 0.1 });
+            model.Axes.Add(new LinearAxis{ Position = AxisPosition.Bottom, MaximumPadding = 0.1, MinimumPadding = 0.1 });
+            model.Axes.Add(new LinearAxis{ Position = AxisPosition.Left, MaximumPadding = 0.1, MinimumPadding = 0.1 });
 
-			return model;
-		}
-	}
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Series/FunctionSeriesExamples.cs
+++ b/ExampleGenerator/Series/FunctionSeriesExamples.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 
-namespace ExampleGenerator
-{
+namespace ExampleGenerator {
 	using OxyPlot;
 	using OxyPlot.Axes;
 	using OxyPlot.Series;
 
-	public class FunctionSeriesExamples
-	{
-		[Export(@"Series\FunctionSeries")]
-		public static PlotModel FunctionSeries()
-		{
+	public class FunctionSeriesExamples {
+		[Export("Series/FunctionSeries")]
+		public static PlotModel FunctionSeries() {
 			var model = new PlotModel{ Title = "Fun with Bats" };
 
 			Func<double, double> batFn1 = (x) => 2 * Math.Sqrt(-Math.Abs(Math.Abs(x) - 1) * Math.Abs(3 - Math.Abs(x)) / ((Math.Abs(x) - 1) * (3 - Math.Abs(x)))) * (1 + Math.Abs(Math.Abs(x) - 3) / (Math.Abs(x) - 3)) * Math.Sqrt(1 - Math.Pow((x / 7), 2)) + (5 + 0.97 * (Math.Abs(x - 0.5) + Math.Abs(x + 0.5)) - 3 * (Math.Abs(x - 0.75) + Math.Abs(x + 0.75))) * (1 + Math.Abs(1 - Math.Abs(x)) / (1 - Math.Abs(x)));

--- a/ExampleGenerator/Series/HeatMapSeriesExamples.cs
+++ b/ExampleGenerator/Series/HeatMapSeriesExamples.cs
@@ -1,150 +1,140 @@
-namespace ExampleGenerator
-{
-    using System;
+namespace ExampleGenerator {
+	using System;
 
-    using OxyPlot;
-    using OxyPlot.Axes;
-    using OxyPlot.Series;
+	using OxyPlot;
+	using OxyPlot.Axes;
+	using OxyPlot.Series;
 
-    public class HeatMapSeriesExamples
-    {
-        [Export(@"Series\HeatMapSeries")]
-        public static PlotModel HeatMapSeries()
-        {
-            var model = new PlotModel { Title = "HeatMapSeries" };
-            double x0 = -3.1;
-            double x1 = 3.1;
-            double y0 = -3;
-            double y1 = 3;
-            Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
-            var xx = ArrayBuilder.CreateVector(x0, x1, 100);
-            var yy = ArrayBuilder.CreateVector(y0, y1, 100);
-            var peaksData = ArrayBuilder.Evaluate(peaks, xx, yy);
+	public class HeatMapSeriesExamples {
+		[Export("Series/HeatMapSeries")]
+		public static PlotModel HeatMapSeries() {
+			var model = new PlotModel { Title = "HeatMapSeries" };
+			double x0 = -3.1;
+			double x1 = 3.1;
+			double y0 = -3;
+			double y1 = 3;
+			Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
+			var xx = ArrayBuilder.CreateVector(x0, x1, 100);
+			var yy = ArrayBuilder.CreateVector(y0, y1, 100);
+			var peaksData = ArrayBuilder.Evaluate(peaks, xx, yy);
 
-            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
+			model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
 
-            var hms = new HeatMapSeries { X0 = x0, X1 = x1, Y0 = y0, Y1 = y1, Data = peaksData };
-            model.Series.Add(hms);
+			var hms = new HeatMapSeries { X0 = x0, X1 = x1, Y0 = y0, Y1 = y1, Data = peaksData };
+			model.Series.Add(hms);
 
-            return model;
-        }
+			return model;
+		}
 
-        [Export(@"Series\HeatMapSeries_linear")]
-        public static PlotModel LinearHeatMap()
-        {
-            var model = new PlotModel { Title = "Heatmap" };
+		[Export("Series/HeatMapSeries_linear")]
+		public static PlotModel LinearHeatMap() {
+			var model = new PlotModel { Title = "Heatmap" };
 
-            // Color axis (the X and Y axes are generated automatically)
-            model.Axes.Add(new LinearColorAxis
-            {
-                Palette = OxyPalettes.Rainbow(100)
-            });
+			// Color axis (the X and Y axes are generated automatically)
+			model.Axes.Add(new LinearColorAxis
+			{
+				Palette = OxyPalettes.Rainbow(100)
+			});
 
-            // generate 1d normal distribution
-            var singleData = new double[100];
-            for (int x = 0; x < 100; ++x)
-            {
-                singleData[x] = Math.Exp((-1.0 / 2.0) * Math.Pow(((double)x - 50.0) / 20.0, 2.0));
-            }
+			// generate 1d normal distribution
+			var singleData = new double[100];
+			for(int x = 0; x < 100; ++x) {
+				singleData[x] = Math.Exp((-1.0 / 2.0) * Math.Pow(((double)x - 50.0) / 20.0, 2.0));
+			}
 
-            // generate 2d normal distribution
-            var data = new double[100, 100];
-            for (int x = 0; x < 100; ++x)
-            {
-                for (int y = 0; y < 100; ++y)
-                {
-                    data[y, x] = singleData[x] * singleData[(y + 30) % 100] * 100;
-                }
-            }
+			// generate 2d normal distribution
+			var data = new double[100, 100];
+			for(int x = 0; x < 100; ++x) {
+				for(int y = 0; y < 100; ++y) {
+					data[y, x] = singleData[x] * singleData[(y + 30) % 100] * 100;
+				}
+			}
 
-            var heatMapSeries = new HeatMapSeries
-            {
-                X0 = 0,
-                X1 = 99,
-                Y0 = 0,
-                Y1 = 99,
-                Interpolate = true,
-                RenderMethod = HeatMapRenderMethod.Bitmap,
-                Data = data
-            };
+			var heatMapSeries = new HeatMapSeries
+			{
+				X0 = 0,
+				X1 = 99,
+				Y0 = 0,
+				Y1 = 99,
+				Interpolate = true,
+				RenderMethod = HeatMapRenderMethod.Bitmap,
+				Data = data
+			};
 
-            model.Series.Add(heatMapSeries);
+			model.Series.Add(heatMapSeries);
 
-            return model;
-        }
+			return model;
+		}
 
-        [Export(@"Series\HeatMapSeries_categorized")]
-        public static PlotModel CategorizedHeatMap()
-        {
-            var model = new PlotModel { Title = "Cakes per Weekday" };
+		[Export("Series/HeatMapSeries_categorized")]
+		public static PlotModel CategorizedHeatMap() {
+			var model = new PlotModel { Title = "Cakes per Weekday" };
 
-            // Weekday axis (horizontal)
-            model.Axes.Add(new CategoryAxis
-            {
-                Position = AxisPosition.Bottom,
+			// Weekday axis (horizontal)
+			model.Axes.Add(new CategoryAxis
+			{
+				Position = AxisPosition.Bottom,
 
-                // Key used for specifying this axis in the HeatMapSeries
-                Key = "WeekdayAxis",
+				// Key used for specifying this axis in the HeatMapSeries
+				Key = "WeekdayAxis",
 
-                // Array of Categories (see above), mapped to one of the coordinates of the 2D-data array
-                ItemsSource = new[]
-                {
-                        "Monday",
-                        "Tuesday",
-                        "Wednesday",
-                        "Thursday",
-                        "Friday",
-                        "Saturday",
-                        "Sunday"
-                }
-            });
+				// Array of Categories (see above), mapped to one of the coordinates of the 2D-data array
+				ItemsSource = new[]
+				{
+					"Monday",
+					"Tuesday",
+					"Wednesday",
+					"Thursday",
+					"Friday",
+					"Saturday",
+					"Sunday"
+				}
+			});
 
-            // Cake type axis (vertical)
-            model.Axes.Add(new CategoryAxis
-            {
-                Position = AxisPosition.Left,
-                Key = "CakeAxis",
-                ItemsSource = new[]
-                {
-                        "Apple cake",
-                        "Baumkuchen",
-                        "Bundt cake",
-                        "Chocolate cake",
-                        "Carrot cake"
-                }
-            });
+			// Cake type axis (vertical)
+			model.Axes.Add(new CategoryAxis
+			{
+				Position = AxisPosition.Left,
+				Key = "CakeAxis",
+				ItemsSource = new[]
+				{
+					"Apple cake",
+					"Baumkuchen",
+					"Bundt cake",
+					"Chocolate cake",
+					"Carrot cake"
+				}
+			});
 
-            // Color axis
-            model.Axes.Add(new LinearColorAxis
-            {
-                Palette = OxyPalettes.Hot(200)
-            });
+			// Color axis
+			model.Axes.Add(new LinearColorAxis
+			{
+				Palette = OxyPalettes.Hot(200)
+			});
 
-            var rand = new Random();
-            var data = new double[7, 5];
-            for (int x = 0; x < 5; ++x)
-            {
-                for (int y = 0; y < 7; ++y)
-                {
-                    data[y, x] = rand.Next(0, 200) * (0.13 * (y + 1));
-                }
-            }
+			var rand = new Random();
+			var data = new double[7, 5];
+			for(int x = 0; x < 5; ++x) {
+				for(int y = 0; y < 7; ++y) {
+					data[y, x] = rand.Next(0, 200) * (0.13 * (y + 1));
+				}
+			}
 
-            var heatMapSeries = new HeatMapSeries
-            {
-                X0 = 0,
-                X1 = 6,
-                Y0 = 0,
-                Y1 = 4,
-                XAxisKey = "WeekdayAxis",
-                YAxisKey = "CakeAxis",
-                RenderMethod = HeatMapRenderMethod.Rectangles,
-                LabelFontSize = 0.2, // neccessary to display the label
-                Data = data
-            };
+			var heatMapSeries = new HeatMapSeries
+			{
+				X0 = 0,
+				X1 = 6,
+				Y0 = 0,
+				Y1 = 4,
+				XAxisKey = "WeekdayAxis",
+				YAxisKey = "CakeAxis",
+				RenderMethod = HeatMapRenderMethod.Rectangles,
+				LabelFontSize = 0.2, // neccessary to display the label
+				Data = data
+			};
 
-            model.Series.Add(heatMapSeries);
-            return model;
-        }
-    }
+			model.Series.Add(heatMapSeries);
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Series/HeatMapSeriesExamples.cs
+++ b/ExampleGenerator/Series/HeatMapSeriesExamples.cs
@@ -1,140 +1,150 @@
-namespace ExampleGenerator {
-	using System;
+namespace ExampleGenerator
+{
+    using System;
 
-	using OxyPlot;
-	using OxyPlot.Axes;
-	using OxyPlot.Series;
+    using OxyPlot;
+    using OxyPlot.Axes;
+    using OxyPlot.Series;
 
-	public class HeatMapSeriesExamples {
-		[Export("Series/HeatMapSeries")]
-		public static PlotModel HeatMapSeries() {
-			var model = new PlotModel { Title = "HeatMapSeries" };
-			double x0 = -3.1;
-			double x1 = 3.1;
-			double y0 = -3;
-			double y1 = 3;
-			Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
-			var xx = ArrayBuilder.CreateVector(x0, x1, 100);
-			var yy = ArrayBuilder.CreateVector(y0, y1, 100);
-			var peaksData = ArrayBuilder.Evaluate(peaks, xx, yy);
+    public class HeatMapSeriesExamples
+    {
+        [Export("Series/HeatMapSeries")]
+        public static PlotModel HeatMapSeries()
+        {
+            var model = new PlotModel { Title = "HeatMapSeries" };
+            double x0 = -3.1;
+            double x1 = 3.1;
+            double y0 = -3;
+            double y1 = 3;
+            Func<double, double, double> peaks = (x, y) => 3 * (1 - x) * (1 - x) * Math.Exp(-(x * x) - (y + 1) * (y + 1)) - 10 * (x / 5 - x * x * x - y * y * y * y * y) * Math.Exp(-x * x - y * y) - 1.0 / 3 * Math.Exp(-(x + 1) * (x + 1) - y * y);
+            var xx = ArrayBuilder.CreateVector(x0, x1, 100);
+            var yy = ArrayBuilder.CreateVector(y0, y1, 100);
+            var peaksData = ArrayBuilder.Evaluate(peaks, xx, yy);
 
-			model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
+            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(500), HighColor = OxyColors.Gray, LowColor = OxyColors.Black });
 
-			var hms = new HeatMapSeries { X0 = x0, X1 = x1, Y0 = y0, Y1 = y1, Data = peaksData };
-			model.Series.Add(hms);
+            var hms = new HeatMapSeries { X0 = x0, X1 = x1, Y0 = y0, Y1 = y1, Data = peaksData };
+            model.Series.Add(hms);
 
-			return model;
-		}
+            return model;
+        }
 
-		[Export("Series/HeatMapSeries_linear")]
-		public static PlotModel LinearHeatMap() {
-			var model = new PlotModel { Title = "Heatmap" };
+        [Export("Series/HeatMapSeries_linear")]
+        public static PlotModel LinearHeatMap()
+        {
+            var model = new PlotModel { Title = "Heatmap" };
 
-			// Color axis (the X and Y axes are generated automatically)
-			model.Axes.Add(new LinearColorAxis
-			{
-				Palette = OxyPalettes.Rainbow(100)
-			});
+            // Color axis (the X and Y axes are generated automatically)
+            model.Axes.Add(new LinearColorAxis
+                {
+                    Palette = OxyPalettes.Rainbow(100)
+                });
 
-			// generate 1d normal distribution
-			var singleData = new double[100];
-			for(int x = 0; x < 100; ++x) {
-				singleData[x] = Math.Exp((-1.0 / 2.0) * Math.Pow(((double)x - 50.0) / 20.0, 2.0));
-			}
+            // generate 1d normal distribution
+            var singleData = new double[100];
+            for (int x = 0; x < 100; ++x)
+            {
+                singleData[x] = Math.Exp((-1.0 / 2.0) * Math.Pow(((double)x - 50.0) / 20.0, 2.0));
+            }
 
-			// generate 2d normal distribution
-			var data = new double[100, 100];
-			for(int x = 0; x < 100; ++x) {
-				for(int y = 0; y < 100; ++y) {
-					data[y, x] = singleData[x] * singleData[(y + 30) % 100] * 100;
-				}
-			}
+            // generate 2d normal distribution
+            var data = new double[100, 100];
+            for (int x = 0; x < 100; ++x)
+            {
+                for (int y = 0; y < 100; ++y)
+                {
+                    data[y, x] = singleData[x] * singleData[(y + 30) % 100] * 100;
+                }
+            }
 
-			var heatMapSeries = new HeatMapSeries
-			{
-				X0 = 0,
-				X1 = 99,
-				Y0 = 0,
-				Y1 = 99,
-				Interpolate = true,
-				RenderMethod = HeatMapRenderMethod.Bitmap,
-				Data = data
-			};
+            var heatMapSeries = new HeatMapSeries
+            {
+                X0 = 0,
+                X1 = 99,
+                Y0 = 0,
+                Y1 = 99,
+                Interpolate = true,
+                RenderMethod = HeatMapRenderMethod.Bitmap,
+                Data = data
+            };
 
-			model.Series.Add(heatMapSeries);
+            model.Series.Add(heatMapSeries);
 
-			return model;
-		}
+            return model;
+        }
 
-		[Export("Series/HeatMapSeries_categorized")]
-		public static PlotModel CategorizedHeatMap() {
-			var model = new PlotModel { Title = "Cakes per Weekday" };
+        [Export("Series/HeatMapSeries_categorized")]
+        public static PlotModel CategorizedHeatMap()
+        {
+            var model = new PlotModel { Title = "Cakes per Weekday" };
 
-			// Weekday axis (horizontal)
-			model.Axes.Add(new CategoryAxis
-			{
-				Position = AxisPosition.Bottom,
+            // Weekday axis (horizontal)
+            model.Axes.Add(new CategoryAxis
+                {
+                    Position = AxisPosition.Bottom,
 
-				// Key used for specifying this axis in the HeatMapSeries
-				Key = "WeekdayAxis",
+                    // Key used for specifying this axis in the HeatMapSeries
+                    Key = "WeekdayAxis",
 
-				// Array of Categories (see above), mapped to one of the coordinates of the 2D-data array
-				ItemsSource = new[]
-				{
-					"Monday",
-					"Tuesday",
-					"Wednesday",
-					"Thursday",
-					"Friday",
-					"Saturday",
-					"Sunday"
-				}
-			});
+                    // Array of Categories (see above), mapped to one of the coordinates of the 2D-data array
+                    ItemsSource = new[]
+                    {
+                        "Monday",
+                        "Tuesday",
+                        "Wednesday",
+                        "Thursday",
+                        "Friday",
+                        "Saturday",
+                        "Sunday"
+                    }
+                });
 
-			// Cake type axis (vertical)
-			model.Axes.Add(new CategoryAxis
-			{
-				Position = AxisPosition.Left,
-				Key = "CakeAxis",
-				ItemsSource = new[]
-				{
-					"Apple cake",
-					"Baumkuchen",
-					"Bundt cake",
-					"Chocolate cake",
-					"Carrot cake"
-				}
-			});
+            // Cake type axis (vertical)
+            model.Axes.Add(new CategoryAxis
+                {
+                    Position = AxisPosition.Left,
+                    Key = "CakeAxis",
+                    ItemsSource = new[]
+                    {
+                        "Apple cake",
+                        "Baumkuchen",
+                        "Bundt cake",
+                        "Chocolate cake",
+                        "Carrot cake"
+                    }
+                });
 
-			// Color axis
-			model.Axes.Add(new LinearColorAxis
-			{
-				Palette = OxyPalettes.Hot(200)
-			});
+            // Color axis
+            model.Axes.Add(new LinearColorAxis
+                {
+                    Palette = OxyPalettes.Hot(200)
+                });
 
-			var rand = new Random();
-			var data = new double[7, 5];
-			for(int x = 0; x < 5; ++x) {
-				for(int y = 0; y < 7; ++y) {
-					data[y, x] = rand.Next(0, 200) * (0.13 * (y + 1));
-				}
-			}
+            var rand = new Random();
+            var data = new double[7, 5];
+            for (int x = 0; x < 5; ++x)
+            {
+                for (int y = 0; y < 7; ++y)
+                {
+                    data[y, x] = rand.Next(0, 200) * (0.13 * (y + 1));
+                }
+            }
 
-			var heatMapSeries = new HeatMapSeries
-			{
-				X0 = 0,
-				X1 = 6,
-				Y0 = 0,
-				Y1 = 4,
-				XAxisKey = "WeekdayAxis",
-				YAxisKey = "CakeAxis",
-				RenderMethod = HeatMapRenderMethod.Rectangles,
-				LabelFontSize = 0.2, // neccessary to display the label
-				Data = data
-			};
+            var heatMapSeries = new HeatMapSeries
+            {
+                X0 = 0,
+                X1 = 6,
+                Y0 = 0,
+                Y1 = 4,
+                XAxisKey = "WeekdayAxis",
+                YAxisKey = "CakeAxis",
+                RenderMethod = HeatMapRenderMethod.Rectangles,
+                LabelFontSize = 0.2, // neccessary to display the label
+                Data = data
+            };
 
-			model.Series.Add(heatMapSeries);
-			return model;
-		}
-	}
+            model.Series.Add(heatMapSeries);
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Series/LineSeriesExamples.cs
+++ b/ExampleGenerator/Series/LineSeriesExamples.cs
@@ -1,47 +1,42 @@
-﻿namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Series;
+﻿namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Series;
 
-    public static class LineSeriesExamples
-    {
-        [Export(@"Series\LineSeries")]
-        public static PlotModel LineSeries()
-        {
-            var model = new PlotModel { Title = "LineSeries" };
-            var lineSeries = new LineSeries();
-            lineSeries.Points.Add(new DataPoint(0, 0));
-            lineSeries.Points.Add(new DataPoint(10, 4));
-            lineSeries.Points.Add(new DataPoint(30, 2));
-            lineSeries.Points.Add(new DataPoint(40, 12));
-            model.Series.Add(lineSeries);
-            return model;
-        }
+	public static class LineSeriesExamples {
+		[Export("Series/LineSeries")]
+		public static PlotModel LineSeries() {
+			var model = new PlotModel { Title = "LineSeries" };
+			var lineSeries = new LineSeries();
+			lineSeries.Points.Add(new DataPoint(0, 0));
+			lineSeries.Points.Add(new DataPoint(10, 4));
+			lineSeries.Points.Add(new DataPoint(30, 2));
+			lineSeries.Points.Add(new DataPoint(40, 12));
+			model.Series.Add(lineSeries);
+			return model;
+		}
 
-        [Export(@"Series\LineSeries-Example2")]
-        public static PlotModel LineSeriesExample2()
-        {
-            var model = new PlotModel { Title = "LineSeries", Subtitle = "Smooth = true" };
-            var lineSeries = new LineSeries { Smooth = true };
-            lineSeries.Points.Add(new DataPoint(0, 0));
-            lineSeries.Points.Add(new DataPoint(10, 4));
-            lineSeries.Points.Add(new DataPoint(30, 2));
-            lineSeries.Points.Add(new DataPoint(40, 12));
-            model.Series.Add(lineSeries);
-            return model;
-        }
+		[Export("Series/LineSeries-Example2")]
+		public static PlotModel LineSeriesExample2() {
+			var model = new PlotModel { Title = "LineSeries", Subtitle = "Smooth = true" };
+			var lineSeries = new LineSeries { Smooth = true };
+			lineSeries.Points.Add(new DataPoint(0, 0));
+			lineSeries.Points.Add(new DataPoint(10, 4));
+			lineSeries.Points.Add(new DataPoint(30, 2));
+			lineSeries.Points.Add(new DataPoint(40, 12));
+			model.Series.Add(lineSeries);
+			return model;
+		}
 
-        [Export(@"Series\LineSeries-Example3")]
-        public static PlotModel LineSeriesExample3()
-        {
-            var model = new PlotModel { Title = "LineSeries", Subtitle = "MarkerType = Circle" };
-            var lineSeries = new LineSeries { MarkerType = MarkerType.Circle };
-            lineSeries.Points.Add(new DataPoint(0, 0));
-            lineSeries.Points.Add(new DataPoint(10, 4));
-            lineSeries.Points.Add(new DataPoint(30, 2));
-            lineSeries.Points.Add(new DataPoint(40, 12));
-            model.Series.Add(lineSeries);
-            return model;
-        }
-    }
+		[Export("Series/LineSeries-Example3")]
+		public static PlotModel LineSeriesExample3() {
+			var model = new PlotModel { Title = "LineSeries", Subtitle = "MarkerType = Circle" };
+			var lineSeries = new LineSeries { MarkerType = MarkerType.Circle };
+			lineSeries.Points.Add(new DataPoint(0, 0));
+			lineSeries.Points.Add(new DataPoint(10, 4));
+			lineSeries.Points.Add(new DataPoint(30, 2));
+			lineSeries.Points.Add(new DataPoint(40, 12));
+			model.Series.Add(lineSeries);
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Series/LineSeriesExamples.cs
+++ b/ExampleGenerator/Series/LineSeriesExamples.cs
@@ -1,42 +1,47 @@
-﻿namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Series;
+﻿namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Series;
 
-	public static class LineSeriesExamples {
-		[Export("Series/LineSeries")]
-		public static PlotModel LineSeries() {
-			var model = new PlotModel { Title = "LineSeries" };
-			var lineSeries = new LineSeries();
-			lineSeries.Points.Add(new DataPoint(0, 0));
-			lineSeries.Points.Add(new DataPoint(10, 4));
-			lineSeries.Points.Add(new DataPoint(30, 2));
-			lineSeries.Points.Add(new DataPoint(40, 12));
-			model.Series.Add(lineSeries);
-			return model;
-		}
+    public static class LineSeriesExamples
+    {
+        [Export("Series/LineSeries")]
+        public static PlotModel LineSeries()
+        {
+            var model = new PlotModel { Title = "LineSeries" };
+            var lineSeries = new LineSeries();
+            lineSeries.Points.Add(new DataPoint(0, 0));
+            lineSeries.Points.Add(new DataPoint(10, 4));
+            lineSeries.Points.Add(new DataPoint(30, 2));
+            lineSeries.Points.Add(new DataPoint(40, 12));
+            model.Series.Add(lineSeries);
+            return model;
+        }
 
-		[Export("Series/LineSeries-Example2")]
-		public static PlotModel LineSeriesExample2() {
-			var model = new PlotModel { Title = "LineSeries", Subtitle = "Smooth = true" };
-			var lineSeries = new LineSeries { Smooth = true };
-			lineSeries.Points.Add(new DataPoint(0, 0));
-			lineSeries.Points.Add(new DataPoint(10, 4));
-			lineSeries.Points.Add(new DataPoint(30, 2));
-			lineSeries.Points.Add(new DataPoint(40, 12));
-			model.Series.Add(lineSeries);
-			return model;
-		}
+        [Export("Series/LineSeries-Example2")]
+        public static PlotModel LineSeriesExample2()
+        {
+            var model = new PlotModel { Title = "LineSeries", Subtitle = "Smooth = true" };
+            var lineSeries = new LineSeries { Smooth = true };
+            lineSeries.Points.Add(new DataPoint(0, 0));
+            lineSeries.Points.Add(new DataPoint(10, 4));
+            lineSeries.Points.Add(new DataPoint(30, 2));
+            lineSeries.Points.Add(new DataPoint(40, 12));
+            model.Series.Add(lineSeries);
+            return model;
+        }
 
-		[Export("Series/LineSeries-Example3")]
-		public static PlotModel LineSeriesExample3() {
-			var model = new PlotModel { Title = "LineSeries", Subtitle = "MarkerType = Circle" };
-			var lineSeries = new LineSeries { MarkerType = MarkerType.Circle };
-			lineSeries.Points.Add(new DataPoint(0, 0));
-			lineSeries.Points.Add(new DataPoint(10, 4));
-			lineSeries.Points.Add(new DataPoint(30, 2));
-			lineSeries.Points.Add(new DataPoint(40, 12));
-			model.Series.Add(lineSeries);
-			return model;
-		}
-	}
+        [Export("Series/LineSeries-Example3")]
+        public static PlotModel LineSeriesExample3()
+        {
+            var model = new PlotModel { Title = "LineSeries", Subtitle = "MarkerType = Circle" };
+            var lineSeries = new LineSeries { MarkerType = MarkerType.Circle };
+            lineSeries.Points.Add(new DataPoint(0, 0));
+            lineSeries.Points.Add(new DataPoint(10, 4));
+            lineSeries.Points.Add(new DataPoint(30, 2));
+            lineSeries.Points.Add(new DataPoint(40, 12));
+            model.Series.Add(lineSeries);
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Series/ScatterSeriesExamples.cs
+++ b/ExampleGenerator/Series/ScatterSeriesExamples.cs
@@ -1,27 +1,31 @@
-﻿namespace ExampleGenerator {
-	using System;
+﻿namespace ExampleGenerator
+{
+    using System;
 
-	using OxyPlot;
-	using OxyPlot.Axes;
-	using OxyPlot.Series;
+    using OxyPlot;
+    using OxyPlot.Axes;
+    using OxyPlot.Series;
 
-	public class ScatterSeriesExamples {
-		[Export("Series/ScatterSeries")]
-		public static PlotModel ScatterSeries() {
-			var model = new PlotModel { Title = "ScatterSeries" };
-			var scatterSeries = new ScatterSeries { MarkerType = MarkerType.Circle };
-			var r = new Random(314);
-			for(int i = 0; i < 100; i++) {
-				var x = r.NextDouble();
-				var y = r.NextDouble();
-				var size = r.Next(5, 15);
-				var colorValue = r.Next(100, 1000);
-				scatterSeries.Points.Add(new ScatterPoint(x, y, size, colorValue));
-			}
+    public class ScatterSeriesExamples
+    {
+        [Export("Series/ScatterSeries")]
+        public static PlotModel ScatterSeries()
+        {
+            var model = new PlotModel { Title = "ScatterSeries" };
+            var scatterSeries = new ScatterSeries { MarkerType = MarkerType.Circle };
+            var r = new Random(314);
+            for (int i = 0; i < 100; i++)
+            {
+                var x = r.NextDouble();
+                var y = r.NextDouble();
+                var size = r.Next(5, 15);
+                var colorValue = r.Next(100, 1000);
+                scatterSeries.Points.Add(new ScatterPoint(x, y, size, colorValue));
+            }
 
-			model.Series.Add(scatterSeries);
-			model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(200) });
-			return model;
-		}
-	}
+            model.Series.Add(scatterSeries);
+            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(200) });
+            return model;
+        }
+    }
 }

--- a/ExampleGenerator/Series/ScatterSeriesExamples.cs
+++ b/ExampleGenerator/Series/ScatterSeriesExamples.cs
@@ -1,31 +1,27 @@
-﻿namespace ExampleGenerator
-{
-    using System;
+﻿namespace ExampleGenerator {
+	using System;
 
-    using OxyPlot;
-    using OxyPlot.Axes;
-    using OxyPlot.Series;
+	using OxyPlot;
+	using OxyPlot.Axes;
+	using OxyPlot.Series;
 
-    public class ScatterSeriesExamples
-    {
-        [Export(@"Series\ScatterSeries")]
-        public static PlotModel ScatterSeries()
-        {
-            var model = new PlotModel { Title = "ScatterSeries" };
-            var scatterSeries = new ScatterSeries { MarkerType = MarkerType.Circle };
-            var r = new Random(314);
-            for (int i = 0; i < 100; i++)
-            {
-                var x = r.NextDouble();
-                var y = r.NextDouble();
-                var size = r.Next(5, 15);
-                var colorValue = r.Next(100, 1000);
-                scatterSeries.Points.Add(new ScatterPoint(x, y, size, colorValue));
-            }
+	public class ScatterSeriesExamples {
+		[Export("Series/ScatterSeries")]
+		public static PlotModel ScatterSeries() {
+			var model = new PlotModel { Title = "ScatterSeries" };
+			var scatterSeries = new ScatterSeries { MarkerType = MarkerType.Circle };
+			var r = new Random(314);
+			for(int i = 0; i < 100; i++) {
+				var x = r.NextDouble();
+				var y = r.NextDouble();
+				var size = r.Next(5, 15);
+				var colorValue = r.Next(100, 1000);
+				scatterSeries.Points.Add(new ScatterPoint(x, y, size, colorValue));
+			}
 
-            model.Series.Add(scatterSeries);
-            model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(200) });
-            return model;
-        }
-    }
+			model.Series.Add(scatterSeries);
+			model.Axes.Add(new LinearColorAxis { Position = AxisPosition.Right, Palette = OxyPalettes.Jet(200) });
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Series/TwoColorLineSeriesExamples.cs
+++ b/ExampleGenerator/Series/TwoColorLineSeriesExamples.cs
@@ -1,27 +1,24 @@
-namespace ExampleGenerator
-{
-    using OxyPlot;
-    using OxyPlot.Series;
+namespace ExampleGenerator {
+	using OxyPlot;
+	using OxyPlot.Series;
 
-    public class TwoColorLineSeriesExamples
-    {
-        [Export(@"Series\TwoColorLineSeries")]
-        public static PlotModel TwoColorLineSeries()
-        {
-            var model = new PlotModel { Title = "TwoColorLineSeries" };
-            var twoColorLineSeries = new TwoColorLineSeries
-                                         {
-                                             Color = OxyColors.Red,
-                                             Color2 = OxyColors.Blue,
-                                             LineStyle = LineStyle.Solid,
-                                             LineStyle2 = LineStyle.Dot
-                                         };
-            twoColorLineSeries.Points.Add(new DataPoint(0, -6));
-            twoColorLineSeries.Points.Add(new DataPoint(10, 4));
-            twoColorLineSeries.Points.Add(new DataPoint(30, -2));
-            twoColorLineSeries.Points.Add(new DataPoint(40, 8));
-            model.Series.Add(twoColorLineSeries);
-            return model;
-        }
-    }
+	public class TwoColorLineSeriesExamples {
+		[Export("Series/TwoColorLineSeries")]
+		public static PlotModel TwoColorLineSeries() {
+			var model = new PlotModel { Title = "TwoColorLineSeries" };
+			var twoColorLineSeries = new TwoColorLineSeries
+			{
+				Color = OxyColors.Red,
+				Color2 = OxyColors.Blue,
+				LineStyle = LineStyle.Solid,
+				LineStyle2 = LineStyle.Dot
+			};
+			twoColorLineSeries.Points.Add(new DataPoint(0, -6));
+			twoColorLineSeries.Points.Add(new DataPoint(10, 4));
+			twoColorLineSeries.Points.Add(new DataPoint(30, -2));
+			twoColorLineSeries.Points.Add(new DataPoint(40, 8));
+			model.Series.Add(twoColorLineSeries);
+			return model;
+		}
+	}
 }

--- a/ExampleGenerator/Series/TwoColorLineSeriesExamples.cs
+++ b/ExampleGenerator/Series/TwoColorLineSeriesExamples.cs
@@ -1,24 +1,27 @@
-namespace ExampleGenerator {
-	using OxyPlot;
-	using OxyPlot.Series;
+namespace ExampleGenerator
+{
+    using OxyPlot;
+    using OxyPlot.Series;
 
-	public class TwoColorLineSeriesExamples {
-		[Export("Series/TwoColorLineSeries")]
-		public static PlotModel TwoColorLineSeries() {
-			var model = new PlotModel { Title = "TwoColorLineSeries" };
-			var twoColorLineSeries = new TwoColorLineSeries
-			{
-				Color = OxyColors.Red,
-				Color2 = OxyColors.Blue,
-				LineStyle = LineStyle.Solid,
-				LineStyle2 = LineStyle.Dot
-			};
-			twoColorLineSeries.Points.Add(new DataPoint(0, -6));
-			twoColorLineSeries.Points.Add(new DataPoint(10, 4));
-			twoColorLineSeries.Points.Add(new DataPoint(30, -2));
-			twoColorLineSeries.Points.Add(new DataPoint(40, 8));
-			model.Series.Add(twoColorLineSeries);
-			return model;
-		}
-	}
+    public class TwoColorLineSeriesExamples
+    {
+        [Export("Series/TwoColorLineSeries")]
+        public static PlotModel TwoColorLineSeries()
+        {
+            var model = new PlotModel { Title = "TwoColorLineSeries" };
+            var twoColorLineSeries = new TwoColorLineSeries
+            {
+                Color = OxyColors.Red,
+                Color2 = OxyColors.Blue,
+                LineStyle = LineStyle.Solid,
+                LineStyle2 = LineStyle.Dot
+            };
+            twoColorLineSeries.Points.Add(new DataPoint(0, -6));
+            twoColorLineSeries.Points.Add(new DataPoint(10, 4));
+            twoColorLineSeries.Points.Add(new DataPoint(30, -2));
+            twoColorLineSeries.Points.Add(new DataPoint(40, 8));
+            model.Series.Add(twoColorLineSeries);
+            return model;
+        }
+    }
 }


### PR DESCRIPTION
Replaced the `\` Path delimiter in the `[Export(@"...")]` annotations with the more general `/` separator and added some logic in the exporting-code, that replaces the separator with the actual separator of the executing platform.
This makes the ExampleGenerator work properly on non-Windows OSs.

Since TruePNG does not seem to exist for other platforms, I added another png optimizer ([OptiPNG](http://optipng.sourceforge.net/)) to work under Linux.

Since the png optimization takes quite some while and the work was done sequentially, I sped up the process by running the exports in parallel.